### PR TITLE
Add RandomVariable log-likelihoods

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -2,10 +2,10 @@ name: PyPI
 on:
   push:
     branches:
-      - master
+      - main
       - auto-release
   pull_request:
-    branches: [master]
+    branches: [main]
   release:
     types: [published]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,11 +3,11 @@ name: Tests
 on:
   push:
     branches:
-      - master
+      - main
       - checks
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   changes:
@@ -107,7 +107,7 @@ jobs:
           if [[ $FAST_COMPILE == "1" ]]; then export AESARA_FLAGS=$AESARA_FLAGS,mode=FAST_COMPILE; fi
           if [[ $FLOAT32 == "1" ]]; then export AESARA_FLAGS=$AESARA_FLAGS,floatX=float32; fi
           export AESARA_FLAGS=$AESARA_FLAGS,warn__ignore_bug_before=all,on_opt_error=raise,on_shape_error=raise,gcc__cxxflags=-pipe
-          python -m pytest -x -r A --verbose --runslow --cov=aesara/ --cov-report=xml:coverage/coverage-${MATRIX_ID}.xml --no-cov-on-fail $PART
+          python -m pytest -x -r A --verbose --cov=aeppl --cov-report=xml:coverage/coverage-${MATRIX_ID}.xml --no-cov-on-fail $PART
         env:
           MATRIX_ID: ${{ steps.matrix-id.outputs.id }}
           MKL_THREADING_LAYER: GNU

--- a/aeppl/__init__.py
+++ b/aeppl/__init__.py
@@ -1,4 +1,4 @@
-
 from ._version import get_versions
-__version__ = get_versions()['version']
+
+__version__ = get_versions()["version"]
 del get_versions

--- a/aeppl/loglik.py
+++ b/aeppl/loglik.py
@@ -1,0 +1,209 @@
+from collections.abc import Mapping
+from functools import singledispatch
+from typing import Dict, Optional, Union
+
+import aesara.tensor as at
+from aesara import config
+from aesara.gradient import disconnected_grad
+from aesara.graph.basic import Constant, clone, graph_inputs, io_toposort
+from aesara.graph.fg import FunctionGraph
+from aesara.graph.op import Op, compute_test_value
+from aesara.tensor.random.op import RandomVariable
+from aesara.tensor.random.opt import local_subtensor_rv_lift
+from aesara.tensor.subtensor import (
+    AdvancedIncSubtensor,
+    AdvancedIncSubtensor1,
+    AdvancedSubtensor,
+    AdvancedSubtensor1,
+    IncSubtensor,
+    Subtensor,
+)
+from aesara.tensor.var import TensorVariable
+
+from aeppl.logpdf import _logpdf
+from aeppl.utils import (
+    extract_rv_and_value_vars,
+    indices_from_subtensor,
+    rvs_to_value_vars,
+)
+
+
+def loglik(
+    var: TensorVariable,
+    rv_values: Optional[
+        Union[TensorVariable, Dict[TensorVariable, TensorVariable]]
+    ] = None,
+    **kwargs,
+) -> TensorVariable:
+    """Create a measure-space (i.e. log-likelihood) graph for a random variable at a given point.
+
+    The input `var` determines which log-likelihood graph is used and
+    `rv_value` is that graph's input parameter.  For example, if `var` is
+    the output of a ``NormalRV`` ``Op``, then the output is a graph of the
+    density function for `var` set to the value `rv_value`.
+
+    Parameters
+    ==========
+    var
+        The `RandomVariable` output that determines the log-likelihood graph.
+    rv_values
+        A variable, or ``dict`` of variables, that represents the value of
+        `var` in its log-likelihood.  If no `rv_value` is provided,
+        ``var.tag.value_var`` will be checked and, when available, used.
+
+    """
+    if not isinstance(rv_values, Mapping):
+        rv_values = {var: rv_values} if rv_values is not None else {}
+
+    rv_var, rv_value_var = extract_rv_and_value_vars(var)
+
+    rv_value = rv_values.get(rv_var, rv_value_var)
+
+    if rv_var is not None and rv_value is None:
+        raise ValueError(f"No value variable specified or associated with {rv_var}")
+
+    if rv_value is not None:
+        rv_value = at.as_tensor(rv_value)
+
+        if rv_var is not None:
+            # Make sure that the value is compatible with the random variable
+            rv_value = rv_var.type.filter_variable(rv_value.astype(rv_var.dtype))
+
+        if rv_value_var is None:
+            rv_value_var = rv_value
+
+    if rv_var is None:
+        if var.owner is not None:
+            return _loglik(
+                var.owner.op,
+                var,
+                rv_values,
+                *var.owner.inputs,
+            )
+
+        return at.zeros_like(var)
+
+    rv_node = rv_var.owner
+
+    rng, size, dtype, *dist_params = rv_node.inputs
+
+    # Here, we plug the actual random variable into the log-likelihood graph,
+    # because we want a log-likelihood graph that only contains
+    # random variables.  This is important, because a random variable's
+    # parameters can contain random variables themselves.
+    # Ultimately, with a graph containing only random variables and
+    # "deterministics", we can simply replace all the random variables with
+    # their value variables and be done.
+
+    # tmp_rv_values = rv_values.copy()
+    # tmp_rv_values[rv_var] = rv_var
+
+    logpdf_var = _logpdf(rv_node.op, rv_value_var, *dist_params, **kwargs)
+
+    # Replace random variables with their value variables
+    replacements = rv_values.copy()
+    replacements.update({rv_var: rv_value, rv_value_var: rv_value})
+
+    (logpdf_var,), _ = rvs_to_value_vars(
+        (logpdf_var,),
+        initial_replacements=replacements,
+    )
+
+    if sum:
+        logpdf_var = at.sum(logpdf_var)
+
+    # Recompute test values for the changes introduced by the replacements
+    # above.
+    if config.compute_test_value != "off":
+        for node in io_toposort(graph_inputs((logpdf_var,)), (logpdf_var,)):
+            compute_test_value(node)
+
+    if rv_var.name is not None:
+        logpdf_var.name = "__logp_%s" % rv_var.name
+
+    return logpdf_var
+
+
+@singledispatch
+def _loglik(
+    op: Op,
+    var: TensorVariable,
+    rvs_to_values: Dict[TensorVariable, TensorVariable],
+    *inputs: TensorVariable,
+    **kwargs,
+):
+    """Create a graph for the log-likelihood of a ``Variable``.
+
+    This function dispatches on the type of ``op``.  If you want to implement
+    new graphs for an ``Op``, register a new function on this dispatcher.
+
+    The default returns a graph producing only zeros.
+
+    """
+    value_var = rvs_to_values.get(var, var)
+    return at.zeros_like(value_var)
+
+
+@_loglik.register(IncSubtensor)
+@_loglik.register(AdvancedIncSubtensor)
+@_loglik.register(AdvancedIncSubtensor1)
+def incsubtensor_loglik(
+    op, var, rvs_to_values, indexed_rv_var, rv_values, *indices, **kwargs
+):
+
+    index = indices_from_subtensor(getattr(op, "idx_list", None), indices)
+
+    _, (new_rv_var,) = clone(
+        tuple(
+            v for v in graph_inputs((indexed_rv_var,)) if not isinstance(v, Constant)
+        ),
+        (indexed_rv_var,),
+        copy_inputs=False,
+        copy_orphans=False,
+    )
+    new_values = at.set_subtensor(disconnected_grad(new_rv_var)[index], rv_values)
+    logp_var = loglik(indexed_rv_var, new_values, **kwargs)
+
+    return logp_var
+
+
+@_loglik.register(Subtensor)
+@_loglik.register(AdvancedSubtensor)
+@_loglik.register(AdvancedSubtensor1)
+def subtensor_loglik(op, var, rvs_to_values, indexed_rv_var, *indices, **kwargs):
+
+    index = indices_from_subtensor(getattr(op, "idx_list", None), indices)
+
+    rv_value = rvs_to_values.get(var, getattr(var.tag, "value_var", None))
+
+    if indexed_rv_var.owner and isinstance(indexed_rv_var.owner.op, RandomVariable):
+
+        # We need to lift the index operation through the random variable so
+        # that we have a new random variable consisting of only the relevant
+        # subset of variables per the index.
+        var_copy = var.owner.clone().default_output()
+        fgraph = FunctionGraph(
+            [i for i in graph_inputs((indexed_rv_var,)) if not isinstance(i, Constant)],
+            [var_copy],
+            clone=False,
+        )
+
+        (lifted_var,) = local_subtensor_rv_lift.transform(
+            fgraph, fgraph.outputs[0].owner
+        )
+
+        new_rvs_to_values = rvs_to_values.copy()
+        new_rvs_to_values[lifted_var] = rv_value
+
+        logp_var = loglik(lifted_var, new_rvs_to_values, **kwargs)
+
+        for idx_var in index:
+            logp_var += loglik(idx_var, rvs_to_values, **kwargs)
+
+    # TODO: We could add the constant case (i.e. `indexed_rv_var.owner is None`)
+    else:
+        raise NotImplementedError(
+            f"`Subtensor` log-likelihood not implemented for {indexed_rv_var.owner}"
+        )
+
+    return logp_var

--- a/aeppl/logpdf.py
+++ b/aeppl/logpdf.py
@@ -1,0 +1,455 @@
+from functools import singledispatch
+
+import aesara.tensor as at
+import aesara.tensor.random.basic as arb
+import numpy as np
+from aesara.assert_op import Assert
+from aesara.graph.op import Op
+from aesara.tensor.slinalg import Cholesky, solve_lower_triangular
+from aesara.tensor.var import TensorVariable
+
+# from aesara.tensor.xlogx import xlogy0
+
+cholesky = Cholesky(lower=True, on_error="nan")
+
+
+def betaln(x, y):
+    return at.gammaln(x) + at.gammaln(y) - at.gammaln(x + y)
+
+
+def binomln(n, k):
+    return at.gammaln(n + 1) - at.gammaln(k + 1) - at.gammaln(n - k + 1)
+
+
+def xlogy0(m, x):
+    # TODO: This should probably be a basic Aesara stabilization
+    return at.switch(at.eq(x, 0), at.switch(at.eq(m, 0), 0.0, -np.inf), m * at.log(x))
+
+
+def logpdf(rv_var, obs, **kwargs):
+    """Create a graph for the log-density/mass of a ``RandomVariable``."""
+    return _logpdf(rv_var.owner.op, obs, *rv_var.owner.inputs, **kwargs)
+
+
+@singledispatch
+def _logpdf(
+    op: Op,
+    value: TensorVariable,
+    *inputs: TensorVariable,
+    **kwargs,
+):
+    """Create a graph for the log-density/mass of a ``RandomVariable``.
+
+    This function dispatches on the type of ``op``, which should be a subclass
+    of ``RandomVariable``.  If you want to implement new density/mass graphs
+    for a ``RandomVariable``, register a new function on this dispatcher.
+
+    The default returns a graph producing only zeros.
+
+    """
+    raise NotImplementedError()
+
+
+@_logpdf.register(arb.UniformRV)
+def uniform_logpdf(op, value, *inputs, **kwargs):
+    lower, upper = inputs[3:]
+    return at.switch(
+        at.bitwise_and(at.ge(value, lower), at.le(value, upper)),
+        at.fill(value, -at.log(upper - lower)),
+        -np.inf,
+    )
+
+
+@_logpdf.register(arb.NormalRV)
+def normal_logpdf(op, value, *inputs, **kwargs):
+    mu, sigma = inputs[3:]
+    res = (
+        -0.5 * at.pow((value - mu) / sigma, 2)
+        - at.log(np.sqrt(2.0 * np.pi))
+        - at.log(sigma)
+    )
+    res = Assert("sigma > 0")(res, at.all(at.gt(sigma, 0.0)))
+    return res
+
+
+@_logpdf.register(arb.HalfNormalRV)
+def halfnormal_logpdf(op, value, *inputs, **kwargs):
+    loc, sigma = inputs[3:]
+    res = (
+        -0.5 * at.pow((value - loc) / sigma, 2)
+        + at.log(np.sqrt(2.0 / np.pi))
+        - at.log(sigma)
+    )
+    res = at.switch(at.ge(value, loc), res, -np.inf)
+    res = Assert("sigma > 0")(res, at.all(at.gt(sigma, 0.0)))
+    return res
+
+
+@_logpdf.register(arb.BetaRV)
+def beta_logpdf(op, value, *inputs, **kwargs):
+    alpha, beta = inputs[3:]
+    res = (
+        at.switch(at.eq(alpha, 1.0), 0.0, (alpha - 1.0) * at.log(value))
+        + at.switch(at.eq(beta, 1.0), 0.0, (beta - 1.0) * at.log1p(-value))
+        - (at.gammaln(alpha) + at.gammaln(beta) - at.gammaln(alpha + beta))
+    )
+    res = at.switch(at.bitwise_and(at.ge(value, 0.0), at.le(value, 1.0)), res, -np.inf)
+    res = Assert("0 <= value <= 1, alpha > 0, beta > 0")(
+        res, at.all(at.gt(alpha, 0.0)), at.all(at.gt(beta, 0.0))
+    )
+    return res
+
+
+@_logpdf.register(arb.ExponentialRV)
+def exponential_logpdf(op, value, *inputs, **kwargs):
+    (mu,) = inputs[3:]
+    res = -at.log(mu) - value / mu
+    res = at.switch(at.ge(value, 0.0), res, -np.inf)
+    res = Assert("mu > 0")(res, at.all(at.gt(mu, 0.0)))
+    return res
+
+
+@_logpdf.register(arb.LaplaceRV)
+def laplace_logpdf(op, value, *inputs, **kwargs):
+    mu, b = inputs[3:]
+    return -at.log(2 * b) - at.abs_(value - mu) / b
+
+
+@_logpdf.register(arb.LogNormalRV)
+def lognormal_logpdf(op, value, *inputs, **kwargs):
+    mu, sigma = inputs[3:]
+    res = (
+        -0.5 * at.pow((at.log(value) - mu) / sigma, 2)
+        - 0.5 * at.log(2.0 * np.pi)
+        - at.log(sigma)
+        - at.log(value)
+    )
+    res = at.switch(at.gt(value, 0.0), res, -np.inf)
+    res = Assert("sigma > 0")(res, at.all(at.gt(sigma, 0)))
+    return res
+
+
+@_logpdf.register(arb.ParetoRV)
+def pareto_logpdf(op, value, *inputs, **kwargs):
+    alpha, m = inputs[3:]
+    res = at.log(alpha) + xlogy0(alpha, m) - xlogy0(alpha + 1.0, value)
+    res = at.switch(at.ge(value, m), res, -np.inf)
+    res = Assert("alpha > 0, m > 0")(
+        res, at.all(at.gt(alpha, 0.0)), at.all(at.gt(m, 0.0))
+    )
+    return res
+
+
+@_logpdf.register(arb.CauchyRV)
+def cauchy_logpdf(op, value, *inputs, **kwargs):
+    alpha, beta = inputs[3:]
+    res = -at.log(np.pi) - at.log(beta) - at.log1p(at.pow((value - alpha) / beta, 2))
+    res = Assert("beta > 0")(res, at.all(at.gt(beta, 0.0)))
+    return res
+
+
+@_logpdf.register(arb.HalfCauchyRV)
+def halfcauchy_logpdf(op, value, *inputs, **kwargs):
+    res = at.log(2) + cauchy_logpdf(op, value, *inputs, **kwargs)
+    loc, _ = inputs[3:]
+    res = at.switch(at.ge(value, loc), res, -np.inf)
+    return res
+
+
+@_logpdf.register(arb.GammaRV)
+def gamma_logpdf(op, value, *inputs, **kwargs):
+    alpha, inv_beta = inputs[3:]
+    beta = at.reciprocal(inv_beta)
+    res = (
+        -at.gammaln(alpha)
+        + xlogy0(alpha, beta)
+        - beta * value
+        + xlogy0(alpha - 1, value)
+    )
+    res = at.switch(at.ge(value, 0.0), res, -np.inf)
+    res = Assert("alpha > 0, beta > 0")(
+        res, at.all(at.gt(alpha, 0.0)), at.all(at.gt(beta, 0.0))
+    )
+    return res
+
+
+@_logpdf.register(arb.InvGammaRV)
+def invgamma_logpdf(op, value, *inputs, **kwargs):
+    alpha, beta = inputs[3:]
+    res = -(alpha + 1) * np.log(value) - at.gammaln(alpha) - 1.0 / value
+    res = (
+        -at.gammaln(alpha)
+        + xlogy0(alpha, beta)
+        - beta / value
+        + xlogy0(-alpha - 1, value)
+    )
+    res = at.switch(at.ge(value, 0.0), res, -np.inf)
+    res = Assert("alpha > 0, beta > 0")(
+        res, at.all(at.gt(alpha, 0.0)), at.all(at.gt(beta, 0.0))
+    )
+    return res
+
+
+@_logpdf.register(arb.WeibullRV)
+def weibull_logpdf(op, value, *inputs, **kwargs):
+    alpha, beta = inputs[3:]
+    res = (
+        at.log(alpha)
+        - at.log(beta)
+        + (alpha - 1.0) * at.log(value / beta)
+        - at.pow(value / beta, alpha)
+    )
+    res = at.switch(at.ge(value, 0.0), res, -np.inf)
+    res = Assert("alpha > 0, beta > 0")(
+        res, at.all(at.gt(alpha, 0.0)), at.all(at.gt(beta, 0.0))
+    )
+    return res
+
+
+@_logpdf.register(arb.VonMisesRV)
+def vonmises_logpdf(op, value, *inputs, **kwargs):
+    mu, kappa = inputs[3:]
+    res = kappa * at.cos(mu - value) - at.log(2 * np.pi) - at.log(at.i0(kappa))
+    # This doesn't match `scipy.stats.vonmises.logpdf`:
+    # res = at.switch(
+    #     at.bitwise_and(at.ge(value, -np.pi), at.le(value, np.pi)), res, -np.inf
+    # )
+    res = Assert("kappa > 0")(res, at.all(at.gt(kappa, 0.0)))
+    return res
+
+
+@_logpdf.register(arb.TriangularRV)
+def triangular_logpdf(op, value, *inputs, **kwargs):
+    lower, c, upper = inputs[3:]
+    res = at.switch(
+        at.lt(value, c),
+        at.log(2 * (value - lower) / ((upper - lower) * (c - lower))),
+        at.log(2 * (upper - value) / ((upper - lower) * (upper - c))),
+    )
+    res = at.switch(
+        at.bitwise_and(at.le(lower, value), at.le(value, upper)), res, -np.inf
+    )
+    res = Assert("lower <= c, c <= upper")(
+        res, at.all(at.le(lower, c)), at.all(at.le(c, upper))
+    )
+    return res
+
+
+@_logpdf.register(arb.GumbelRV)
+def gumbel_logpdf(op, value, *inputs, **kwargs):
+    mu, beta = inputs[3:]
+    z = (value - mu) / beta
+    res = -z - at.exp(-z) - at.log(beta)
+    res = Assert("0 < beta")(res, at.all(at.lt(0.0, beta)))
+    return res
+
+
+@_logpdf.register(arb.LogisticRV)
+def logistic_logpdf(op, value, *inputs, **kwargs):
+    mu, s = inputs[3:]
+    z = (value - mu) / s
+    res = -z - at.log(s) - 2.0 * at.log1p(at.exp(-z))
+    res = Assert("0 < s")(res, at.all(at.lt(0.0, s)))
+    return res
+
+
+@_logpdf.register(arb.BinomialRV)
+def binomial_logpdf(op, value, *inputs, **kwargs):
+    n, p = inputs[3:]
+    res = binomln(n, value) + xlogy0(value, p) + xlogy0(n - value, 1.0 - p)
+    res = at.switch(at.bitwise_and(at.le(0, value), at.le(value, n)), res, -np.inf)
+    res = Assert("0 <= p, p <= 1")(res, at.all(at.le(0.0, p)), at.all(at.le(p, 1.0)))
+    return res
+
+
+@_logpdf.register(arb.BetaBinomialRV)
+def betabinomial_logpdf(op, value, *inputs, **kwargs):
+    n, alpha, beta = inputs[3:]
+    res = (
+        binomln(n, value)
+        + betaln(value + alpha, n - value + beta)
+        - betaln(alpha, beta)
+    )
+    res = at.switch(at.bitwise_and(at.le(0, value), at.le(value, n)), res, -np.inf)
+    res = Assert("0 < alpha, 0 < beta")(
+        res, at.all(at.lt(0.0, alpha)), at.all(at.lt(0.0, beta))
+    )
+    return res
+
+
+@_logpdf.register(arb.BernoulliRV)
+def bernoulli_logpdf(op, value, *inputs, **kwargs):
+    (p,) = inputs[3:]
+    res = at.switch(value, at.log(p), at.log(1.0 - p))
+    res = at.switch(at.bitwise_and(at.le(0, value), at.le(value, 1)), res, -np.inf)
+    res = Assert("0 <= p <= 1")(res, at.all(at.le(0.0, p)), at.all(at.le(p, 1.0)))
+    return res
+
+
+@_logpdf.register(arb.PoissonRV)
+def poisson_logpdf(op, value, *inputs, **kwargs):
+    (mu,) = inputs[3:]
+    res = xlogy0(value, mu) - at.gammaln(value + 1) - mu
+    res = at.switch(at.le(0, value), res, -np.inf)
+    res = Assert("0 <= mu")(res, at.all(at.le(0.0, mu)))
+    res = at.switch(at.bitwise_and(at.eq(mu, 0.0), at.eq(value, 0.0)), 0.0, res)
+    return res
+
+
+@_logpdf.register(arb.NegBinomialRV)
+def nbinom_logpdf(op, value, *inputs, **kwargs):
+    n, p = inputs[3:]
+    mu = n * (1 - p) / p
+    res = (
+        binomln(value + n - 1, value)
+        + xlogy0(value, mu / (mu + n))
+        + xlogy0(n, n / (mu + n))
+    )
+    res = at.switch(at.le(0, value), res, -np.inf)
+    res = Assert("0 < mu, 0 < n")(res, at.all(at.lt(0.0, mu)), at.all(at.lt(0.0, n)))
+    res = at.switch(at.gt(n, 1e10), poisson_logpdf(op, value, *inputs[:3], mu), res)
+    return res
+
+
+@_logpdf.register(arb.GeometricRV)
+def geometric_logpdf(op, value, *inputs, **kwargs):
+    (p,) = inputs[3:]
+    res = at.log(p) + xlogy0(value - 1, 1 - p)
+    res = at.switch(at.le(1, value), res, -np.inf)
+    res = Assert("0 <= p <= 1")(res, at.all(at.le(0.0, p)), at.all(at.ge(1.0, p)))
+    return res
+
+
+@_logpdf.register(arb.HyperGeometricRV)
+def hypergeometric_logpdf(op, value, *inputs, **kwargs):
+    good, bad, n = inputs[3:]
+    total = good + bad
+    res = (
+        betaln(good + 1, 1)
+        + betaln(bad + 1, 1)
+        + betaln(total - n + 1, n + 1)
+        - betaln(value + 1, good - value + 1)
+        - betaln(n - value + 1, bad - n + value + 1)
+        - betaln(total + 1, 1)
+    )
+    lower = at.switch(at.gt(n - total + good, 0), n - total + good, 0)
+    upper = at.switch(at.lt(good, n), good, n)
+    res = at.switch(
+        at.bitwise_and(at.le(lower, value), at.le(value, upper)), res, -np.inf
+    )
+    return res
+
+
+@_logpdf.register(arb.CategoricalRV)
+def categorical_logpdf(op, value, *inputs, **kwargs):
+    (p,) = inputs[3:]
+
+    raise NotImplementedError()
+
+    p_ = p
+    p = p_ / at.sum(p_, axis=-1, keepdims=True)
+
+    # FIXME: Why waste a `clip` on these?  If they're out of range, that's
+    # simply an error/invalid inputs.  Use `Assert` instead.
+    k = at.shape(p)[-1]
+    value_clip = at.clip(value, 0, k - 1)
+
+    if p.ndim > 1:
+        # FIXME: This could probably be done much easier with something like `at.ogrid`.
+        # E.g. something like
+        # ind_slices = tuple(at.ogrid[[slice(None, d) for d in tuple(p.shape)[:-1]]])
+        # However, if that produces an `AdvancedSubtensor*` and this approach doesn't,
+        # then this one is probably better.
+        pass
+
+        # if p.ndim > value_clip.ndim:
+        #     value_clip = at.shape_padleft(value_clip, p_.ndim - value_clip.ndim)
+        # elif p.ndim < value_clip.ndim:
+        #     p = at.shape_padleft(p, value_clip.ndim - p_.ndim)
+        # pattern = (p.ndim - 1,) + tuple(range(p.ndim - 1))
+        #
+        # res = at.log(
+        #     take_along_axis(
+        #         p.dimshuffle(pattern),
+        #         value_clip,
+        #     )
+        # )
+    else:
+        res = at.log(p[value_clip])
+
+    res = at.switch(at.bitwise_and(at.le(0, value), at.le(value, k - 1)), res, -np.inf)
+    res = Assert("0 <= p <= 1")(
+        res, at.all(at.ge(p_, 0.0), axis=-1), at.all(at.le(p, 1.0), axis=-1)
+    )
+    return res
+
+
+@_logpdf.register(arb.MvNormalRV)
+def mvnormal_logpdf(op, value, *inputs, **kwargs):
+    mu, cov = inputs[3:]
+
+    r = value - mu
+    cov_chol = cholesky(cov)
+
+    cov_chol_diag = at.diag(cov_chol)
+
+    # TODO: Tag these matrices as positive definite when they're created
+    # Use pseudo-determinant instead.  E.g. from SciPy,
+    # s, u = eigh(cov)
+    # factor = {'f': 1E3, 'd': 1E6}
+    # t = s.numpy_dtype.char.lower()
+    # cond = factor[t] * np.finfo(t).eps
+    # eps = cond * at.max(at.abs_(s))
+    # n = s[at.gt(s, eps)]
+
+    all_pos_definite = at.all(at.gt(cov_chol_diag, 0))
+    cov_chol = at.switch(all_pos_definite, cov_chol, 1)
+
+    z_T = solve_lower_triangular(cov_chol, r.T).T
+    quaddist = at.pow(z_T, 2).sum(axis=-1)
+
+    logdet = at.sum(at.log(cov_chol_diag))
+
+    n = value.shape[-1]
+    res = -0.5 * n * np.log(2 * np.pi) - 0.5 * quaddist - logdet
+    res = Assert("0 < diag(Sigma)")(res, all_pos_definite)
+    return res
+
+
+@_logpdf.register(arb.DirichletRV)
+def dirichlet_logpdf(op, value, *inputs, **kwargs):
+    (alpha,) = inputs[3:]
+    res = at.sum(at.gammaln(alpha)) - at.gammaln(at.sum(alpha))
+    res = -res + at.sum((xlogy0(alpha - 1, value.T)).T, axis=0)
+    # res = at.sum(logpow(value, alpha - 1) - at.gammaln(alpha), axis=-1) + at.gammaln(
+    #     at.sum(alpha, axis=-1)
+    # )
+    res = at.switch(
+        at.bitwise_and(
+            at.all(at.le(0.0, value), axis=-1), at.all(at.le(value, 1.0), axis=-1)
+        ),
+        res,
+        -np.inf,
+    )
+    res = Assert("0 < alpha")(res, at.all(at.lt(0.0, alpha)))
+    return res
+
+
+@_logpdf.register(arb.MultinomialRV)
+def multinomial_logpdf(op, value, *inputs, **kwargs):
+    n, p = inputs[3:]
+    res = at.gammaln(n + 1) + at.sum(-at.gammaln(value + 1) + xlogy0(value, p), axis=-1)
+    res = at.switch(
+        at.bitwise_and(
+            at.all(at.le(0.0, value), axis=-1), at.eq(at.sum(value, axis=-1), n)
+        ),
+        res,
+        -np.inf,
+    )
+    res = Assert("p <= 1, sum(p) == 1, n >= 0")(
+        res,
+        at.all(at.le(p, 1)),
+        at.all(at.eq(at.sum(p, axis=-1), 1)),
+        at.all(at.ge(n, 0)),
+    )
+    return res

--- a/aeppl/utils.py
+++ b/aeppl/utils.py
@@ -1,0 +1,275 @@
+import warnings
+from typing import (
+    Callable,
+    Dict,
+    Generator,
+    Iterable,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
+
+import aesara.tensor as at
+import numpy as np
+from aesara import config
+from aesara.graph.basic import Constant, Variable, clone_get_equiv, graph_inputs, walk
+from aesara.graph.fg import FunctionGraph
+from aesara.graph.op import compute_test_value
+from aesara.graph.type import CType
+from aesara.tensor.random.op import RandomVariable
+from aesara.tensor.sharedvar import SharedVariable
+from aesara.tensor.subtensor import AdvancedIncSubtensor, AdvancedIncSubtensor1
+from aesara.tensor.var import TensorVariable
+
+PotentialShapeType = Union[
+    int,
+    np.ndarray,
+    Tuple[Union[int, Variable], ...],
+    List[Union[int, Variable]],
+    Variable,
+]
+
+
+def change_rv_size(
+    rv_var: TensorVariable,
+    new_size: PotentialShapeType,
+    expand: Optional[bool] = False,
+) -> TensorVariable:
+    """Change or expand the size of a `RandomVariable`.
+
+    Parameters
+    ==========
+    rv_var
+        The `RandomVariable` output.
+    new_size
+        The new size.
+    expand:
+        Expand the existing size by `new_size`.
+
+    """
+    rv_node = rv_var.owner
+    rng, size, dtype, *dist_params = rv_node.inputs
+    name = rv_var.name
+    tag = rv_var.tag
+
+    if expand:
+        if rv_node.op.ndim_supp == 0 and at.get_vector_length(size) == 0:
+            size = rv_node.op._infer_shape(size, dist_params)
+        new_size = tuple(at.atleast_1d(new_size)) + tuple(size)
+
+    # Make sure the new size is a tensor. This helps to not unnecessarily pick
+    # up a `Cast` in some cases
+    new_size = at.as_tensor(new_size, ndim=1, dtype="int64")
+
+    new_rv_node = rv_node.op.make_node(rng, new_size, dtype, *dist_params)
+    rv_var = new_rv_node.outputs[-1]
+    rv_var.name = name
+    for k, v in tag.__dict__.items():
+        rv_var.tag.__dict__.setdefault(k, v)
+
+    if config.compute_test_value != "off":
+        compute_test_value(new_rv_node)
+
+    return rv_var
+
+
+def extract_rv_and_value_vars(
+    var: TensorVariable,
+) -> Tuple[TensorVariable, TensorVariable]:
+    """Return a random variable and its observations, value variable, or ``None``.
+
+    Parameters
+    ==========
+    var
+        A variable corresponding to a ``RandomVariable``.
+
+    Returns
+    =======
+    The first value in the tuple is the ``RandomVariable`` and the second is
+    the observations variable or the measure/log-likelihood value variable.
+
+    """
+    if not var.owner:
+        return None, None
+
+    if isinstance(var.owner.op, RandomVariable):
+        rv_value = getattr(var.tag, "observations", getattr(var.tag, "value_var", None))
+        return var, rv_value
+
+    return None, None
+
+
+def extract_obs_data(x: TensorVariable) -> np.ndarray:
+    """Extract data from observed symbolic variables.
+
+    Raises
+    ------
+    TypeError
+
+    """
+    if isinstance(x, Constant):
+        return x.data
+    if isinstance(x, SharedVariable):
+        return x.get_value()
+    if x.owner and isinstance(
+        x.owner.op, (AdvancedIncSubtensor, AdvancedIncSubtensor1)
+    ):
+        array_data = extract_obs_data(x.owner.inputs[0])
+        mask_idx = tuple(extract_obs_data(i) for i in x.owner.inputs[2:])
+        mask = np.zeros_like(array_data)
+        mask[mask_idx] = 1
+        return np.ma.MaskedArray(array_data, mask)
+
+    raise TypeError(f"Data cannot be extracted from {x}")
+
+
+def walk_model(
+    graphs: Iterable[TensorVariable],
+    walk_past_rvs: bool = False,
+    stop_at_vars: Optional[Set[TensorVariable]] = None,
+    expand_fn: Callable[[TensorVariable], Iterable[TensorVariable]] = lambda var: [],
+) -> Generator[TensorVariable, None, None]:
+    """Walk model graphs and yield their nodes.
+
+    By default, these walks will not go past ``RandomVariable`` nodes.
+
+    Parameters
+    ==========
+    graphs
+        The graphs to walk.
+    walk_past_rvs
+        If ``True``, the walk will not terminate at ``RandomVariable``s.
+    stop_at_vars
+        A list of variables at which the walk will terminate.
+    expand_fn
+        A function that returns the next variable(s) to be traversed.
+    """
+    if stop_at_vars is None:
+        stop_at_vars = set()
+
+    def expand(var):
+        new_vars = expand_fn(var)
+
+        if (
+            var.owner
+            and (walk_past_rvs or not isinstance(var.owner.op, RandomVariable))
+            and (var not in stop_at_vars)
+        ):
+            new_vars.extend(reversed(var.owner.inputs))
+
+        return new_vars
+
+    yield from walk(graphs, expand, False)
+
+
+def replace_rvs_in_graphs(
+    graphs: Iterable[TensorVariable],
+    replacement_fn: Callable[[TensorVariable], Dict[TensorVariable, TensorVariable]],
+    initial_replacements: Optional[Dict[TensorVariable, TensorVariable]] = None,
+    **kwargs,
+) -> Tuple[TensorVariable, Dict[TensorVariable, TensorVariable]]:
+    """Replace random variables in graphs.
+
+    This will *not* recompute test values.
+
+    Parameters
+    ==========
+    graphs
+        The graphs in which random variables are to be replaced.
+
+    Returns
+    =======
+    A ``tuple`` containing the transformed graphs and a ``dict`` of the
+    replacements that were made.
+    """
+    replacements = {}
+    if initial_replacements:
+        replacements.update(initial_replacements)
+
+    def expand_replace(var):
+        new_nodes = []
+        if var.owner and isinstance(var.owner.op, RandomVariable):
+            new_nodes.extend(replacement_fn(var, replacements))
+        return new_nodes
+
+    for var in walk_model(graphs, expand_fn=expand_replace, **kwargs):
+        pass
+
+    if replacements:
+        inputs = [i for i in graph_inputs(graphs) if not isinstance(i, Constant)]
+        equiv = {k: k for k in replacements.keys()}
+        equiv = clone_get_equiv(inputs, graphs, False, False, equiv)
+
+        fg = FunctionGraph(
+            [equiv[i] for i in inputs],
+            [equiv[o] for o in graphs],
+            clone=False,
+        )
+
+        fg.replace_all(replacements.items(), import_missing=True)
+
+        graphs = list(fg.outputs)
+
+    return graphs, replacements
+
+
+def rvs_to_value_vars(
+    graphs: Iterable[TensorVariable],
+    initial_replacements: Optional[Dict[TensorVariable, TensorVariable]] = None,
+    **kwargs,
+) -> Tuple[TensorVariable, Dict[TensorVariable, TensorVariable]]:
+    """Replace random variables in graphs with their value variables.
+
+    This will *not* recompute test values in the resulting graphs.
+
+    Parameters
+    ==========
+    graphs
+        The graphs in which to perform the replacements.
+    initial_replacements
+        A ``dict`` containing the initial replacements to be made.
+
+    """
+
+    def replace_fn(var, replacements):
+        rv_var, rv_value_var = extract_rv_and_value_vars(var)
+
+        if rv_value_var is None:
+            warnings.warn(
+                f"No value variable found for {rv_var}; "
+                "the random variable will not be replaced."
+            )
+            return []
+
+        replacements[var] = rv_value_var
+
+        # In case the value variable is itself a graph, we walk it for
+        # potential replacements
+        return [rv_value_var]
+
+    return replace_rvs_in_graphs(graphs, replace_fn, initial_replacements, **kwargs)
+
+
+def convert_indices(indices, entry):
+    if indices and isinstance(entry, CType):
+        rval = indices.pop(0)
+        return rval
+    elif isinstance(entry, slice):
+        return slice(
+            convert_indices(indices, entry.start),
+            convert_indices(indices, entry.stop),
+            convert_indices(indices, entry.step),
+        )
+    else:
+        return entry
+
+
+def indices_from_subtensor(idx_list, indices):
+    """Compute a useable index tuple from the inputs of a ``*Subtensor**`` ``Op``."""
+    return tuple(
+        tuple(convert_indices(list(indices), idx) for idx in idx_list)
+        if idx_list
+        else indices
+    )

--- a/tests/test_loglik.py
+++ b/tests/test_loglik.py
@@ -1,0 +1,182 @@
+import aesara
+import aesara.tensor as at
+import numpy as np
+import pytest
+import scipy.stats.distributions as sp
+from aesara.gradient import DisconnectedGrad
+from aesara.graph.basic import Constant, graph_inputs
+from aesara.graph.fg import FunctionGraph
+from aesara.tensor.random.op import RandomVariable
+from aesara.tensor.subtensor import (
+    AdvancedIncSubtensor,
+    AdvancedIncSubtensor1,
+    AdvancedSubtensor,
+    AdvancedSubtensor1,
+    IncSubtensor,
+    Subtensor,
+)
+
+from aeppl.loglik import loglik
+from aeppl.utils import walk_model
+from tests.utils import assert_no_rvs
+
+
+@pytest.mark.xfail(reason="loglik needs to be refactored")
+def test_loglik_basic():
+    """Make sure we can compute a log-likelihood for a hierarchical model."""
+
+    a = at.random.uniform(0.0, 1.0)
+    a.name = "a"
+    c = at.random.normal()
+    c.name = "c"
+    b_l = c * a + 2.0
+    b = at.random.uniform(b_l, b_l + 1.0)
+    b.name = "b"
+
+    a_value_var = a.copy()
+    b_value_var = b.copy()
+    c_value_var = c.copy()
+    # assert a_value_var.tag.transform
+    # assert b_value_var.tag.transform
+
+    b_logp = loglik(b, b_value_var)
+
+    res_ancestors = list(walk_model((b_logp,), walk_past_rvs=True))
+    res_rv_ancestors = [
+        v for v in res_ancestors if v.owner and isinstance(v.owner.op, RandomVariable)
+    ]
+
+    # There shouldn't be any `RandomVariable`s in the resulting graph
+    assert len(res_rv_ancestors) == 0
+    assert b_value_var in res_ancestors
+    assert c_value_var in res_ancestors
+    assert a_value_var in res_ancestors
+
+
+@pytest.mark.xfail(reason="loglik needs to be refactored")
+@pytest.mark.parametrize(
+    "indices, size",
+    [
+        (slice(0, 2), 5),
+        (np.r_[True, True, False, False, True], 5),
+        (np.r_[0, 1, 4], 5),
+        ((np.array([0, 1, 4]), np.array([0, 1, 4])), (5, 5)),
+    ],
+)
+def test_logpt_incsubtensor(indices, size):
+    """Make sure we can compute a log-likelihood for ``Y[idx] = data`` where ``Y`` is univariate."""
+
+    mu = np.power(10, np.arange(np.prod(size))).reshape(size)
+    data = mu[indices]
+    sigma = 0.001
+    rng = aesara.shared(np.random.RandomState(232), borrow=True)
+
+    a = at.random.normal(mu, sigma, size=size, rng=rng)
+    a.name = "a"
+
+    a_idx = at.set_subtensor(a[indices], data)
+
+    assert isinstance(
+        a_idx.owner.op, (IncSubtensor, AdvancedIncSubtensor, AdvancedIncSubtensor1)
+    )
+
+    a_idx_value_var = a_idx.type()
+    a_idx_value_var.name = "a_idx_value"
+
+    a_idx_logp = loglik(a_idx, a_idx_value_var)
+
+    logp_vals = a_idx_logp.eval()
+
+    # The indices that were set should all have the same log-likelihood values,
+    # because the values they were set to correspond to the unique means along
+    # that dimension.  This helps us confirm that the log-likelihood is
+    # associating the assigned values with their correct parameters.
+    exp_obs_logps = sp.norm.logpdf(mu, mu, sigma)[indices]
+    np.testing.assert_almost_equal(logp_vals[indices], exp_obs_logps)
+
+    # Next, we need to confirm that the unset indices are being sampled
+    # from the original random variable in the correct locations.
+    # rng.get_value(borrow=True).seed(232)
+
+    res_ancestors = list(walk_model((a_idx_logp,), walk_past_rvs=True))
+    res_rv_ancestors = tuple(
+        v for v in res_ancestors if v.owner and isinstance(v.owner.op, RandomVariable)
+    )
+
+    # The imputed missing values are drawn from the original distribution
+    (a_new,) = res_rv_ancestors
+    assert a_new is not a
+    assert a_new.owner.op == a.owner.op
+
+    fg = FunctionGraph(
+        [v for v in graph_inputs((a_idx_logp,)) if not isinstance(v, Constant)],
+        [a_idx_logp],
+        clone=False,
+    )
+
+    ((a_client, _),) = fg.clients[a_new]
+    # The imputed values should be treated as constants when gradients are
+    # taken
+    assert isinstance(a_client.op, DisconnectedGrad)
+
+    ((a_client, _),) = fg.clients[a_client.outputs[0]]
+    assert isinstance(
+        a_client.op, (IncSubtensor, AdvancedIncSubtensor, AdvancedIncSubtensor1)
+    )
+    indices = tuple(i.eval() for i in a_client.inputs[2:])
+    np.testing.assert_almost_equal(indices, indices)
+
+
+@pytest.mark.xfail(reason="loglik needs to be refactored")
+def test_loglik_subtensor():
+    """Make sure we can compute a log-likelihood for ``Y[I]`` where ``Y`` and ``I`` are random variables."""
+
+    size = 5
+
+    mu_base = np.power(10, np.arange(np.prod(size))).reshape(size)
+    mu = np.stack([mu_base, -mu_base])
+    sigma = 0.001
+    rng = aesara.shared(np.random.RandomState(232), borrow=True)
+
+    A_rv = at.random.normal(mu, sigma, rng=rng)
+    A_rv.name = "A"
+
+    p = 0.5
+
+    I_rv = at.random.bernoulli(p, size=size, rng=rng)
+    I_rv.name = "I"
+
+    A_idx = A_rv[I_rv, at.ogrid[A_rv.shape[-1] :]]
+
+    assert isinstance(
+        A_idx.owner.op, (Subtensor, AdvancedSubtensor, AdvancedSubtensor1)
+    )
+
+    A_idx_value_var = A_idx.type()
+    A_idx_value_var.name = "A_idx_value"
+
+    I_value_var = I_rv.type()
+    I_value_var.name = "I_value"
+
+    A_idx_logp = loglik(A_idx, {A_idx: A_idx_value_var, I_rv: I_value_var})
+
+    logp_vals_fn = aesara.function([A_idx_value_var, I_value_var], A_idx_logp)
+
+    # The compiled graph should not contain any `RandomVariables`
+    assert_no_rvs(logp_vals_fn.maker.fgraph.outputs[0])
+
+    decimals = 6 if aesara.config.floatX == "float64" else 4
+
+    for i in range(10):
+        bern_sp = sp.bernoulli(p)
+        I_value = bern_sp.rvs(size=size).astype(I_rv.dtype)
+
+        norm_sp = sp.norm(mu[I_value, np.ogrid[mu.shape[1] :]], sigma)
+        A_idx_value = norm_sp.rvs().astype(A_idx.dtype)
+
+        exp_obs_logps = norm_sp.logpdf(A_idx_value)
+        exp_obs_logps += bern_sp.logpmf(I_value)
+
+        logp_vals = logp_vals_fn(A_idx_value, I_value)
+
+        np.testing.assert_almost_equal(logp_vals, exp_obs_logps, decimal=decimals)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,113 @@
+import aesara.tensor as at
+import numpy as np
+from aesara.graph.basic import Constant, ancestors
+from aesara.tensor.random.basic import normal, uniform
+
+from aeppl.utils import change_rv_size, rvs_to_value_vars, walk_model
+from tests.utils import assert_no_rvs
+
+
+def test_change_rv_size():
+    loc = at.as_tensor_variable([1, 2])
+    rv = normal(loc=loc)
+    assert rv.ndim == 1
+    assert tuple(rv.shape.eval()) == (2,)
+
+    rv_new = change_rv_size(rv, new_size=(3,), expand=True)
+    assert rv_new.ndim == 2
+    assert tuple(rv_new.shape.eval()) == (3, 2)
+
+    # Make sure that the shape used to determine the expanded size doesn't
+    # depend on the old `RandomVariable`.
+    rv_new_ancestors = set(ancestors((rv_new,)))
+    assert loc in rv_new_ancestors
+    assert rv not in rv_new_ancestors
+
+    rv_newer = change_rv_size(rv_new, new_size=(4,), expand=True)
+    assert rv_newer.ndim == 3
+    assert tuple(rv_newer.shape.eval()) == (4, 3, 2)
+
+    # Make sure we avoid introducing a `Cast` by converting the new size before
+    # constructing the new `RandomVariable`
+    rv = normal(0, 1)
+    new_size = np.array([4, 3], dtype="int32")
+    rv_newer = change_rv_size(rv, new_size=new_size, expand=False)
+    assert rv_newer.ndim == 2
+    assert isinstance(rv_newer.owner.inputs[1], Constant)
+    assert tuple(rv_newer.shape.eval()) == (4, 3)
+
+    rv = normal(0, 1)
+    new_size = at.as_tensor(np.array([4, 3], dtype="int32"))
+    rv_newer = change_rv_size(rv, new_size=new_size, expand=True)
+    assert rv_newer.ndim == 2
+    assert tuple(rv_newer.shape.eval()) == (4, 3)
+
+    rv = normal(0, 1)
+    new_size = at.as_tensor(2, dtype="int32")
+    rv_newer = change_rv_size(rv, new_size=new_size, expand=True)
+    assert rv_newer.ndim == 1
+    assert tuple(rv_newer.shape.eval()) == (2,)
+
+
+def test_walk_model():
+    d = at.vector("d")
+    b = at.vector("b")
+    c = uniform(0.0, d)
+    c.name = "c"
+    e = at.log(c)
+    a = normal(e, b)
+    a.name = "a"
+
+    test_graph = at.exp(a + 1)
+    res = list(walk_model((test_graph,)))
+    assert a in res
+    assert c not in res
+
+    res = list(walk_model((test_graph,), walk_past_rvs=True))
+    assert a in res
+    assert c in res
+
+    res = list(walk_model((test_graph,), walk_past_rvs=True, stop_at_vars={e}))
+    assert a in res
+    assert c not in res
+
+
+def test_rvs_to_value_vars():
+
+    a = at.random.uniform(0.0, 1.0)
+    a.name = "a"
+    a.tag.value_var = a_value_var = a.clone()
+
+    b = at.random.uniform(0, a + 1.0)
+    b.name = "b"
+    b.tag.value_var = b_value_var = b.clone()
+
+    c = at.random.normal()
+    c.name = "c"
+    c.tag.value_var = c_value_var = c.clone()
+
+    d = at.log(c + b) + 2.0
+
+    (res,), replaced = rvs_to_value_vars((d,))
+
+    assert res.owner.op == at.add
+    log_output = res.owner.inputs[0]
+    assert log_output.owner.op == at.log
+    log_add_output = res.owner.inputs[0].owner.inputs[0]
+    assert log_add_output.owner.op == at.add
+    c_output = log_add_output.owner.inputs[0]
+
+    # We make sure that the random variables were replaced
+    # with their value variables
+    assert c_output == c_value_var
+    b_output = log_add_output.owner.inputs[1]
+    assert b_output == b_value_var
+
+    # There shouldn't be any `RandomVariable`s in the resulting graph
+    assert_no_rvs(res)
+
+    res_ancestors = list(walk_model((res,), walk_past_rvs=True))
+
+    assert b_value_var in res_ancestors
+    assert c_value_var in res_ancestors
+    assert a_value_var not in res_ancestors

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,9 @@
+from aesara.graph.basic import ancestors
+from aesara.tensor.random.op import RandomVariable
+
+
+def assert_no_rvs(var):
+    assert not any(
+        isinstance(v.owner.op, RandomVariable) for v in ancestors([var]) if v.owner
+    )
+    return var


### PR DESCRIPTION
This PR adds an initial log-likelihood entry-point function and log-pdf/pmf functions for most of the `aesara.tensor.random.basic` `RandomVariable`s.

The general idea is that the `logpdf` dispatch function simply adds `logpdf`s in the spirit of `scipy.stats`.  These implementations should be flexible when it comes to the shapes of the observed/value variables (e.g. the `RandomVariable` shouldn't need to be resized to produce a graph).

The `loglik` functions&mdash;and the associated `_loglik` dispatch functions&mdash;compute log-likelihoods for graphs potentially containing multiple `RandomVariable`s.  

`loglik` needs to be entirely rewritten, though.  Simply put, we would be better off using the `Optimization` framework.  See [the comments here](https://github.com/pymc-devs/pymc3/pull/4653#pullrequestreview-641633382) for more information.  

Nevertheless, we'll probably merge this before everything is fixed, just to establish something from which we can base our log-likelihood-requiring work.