### PR TITLE
Implement a general mixture log-probability rewrite

### DIFF
--- a/aeppl/__init__.py
+++ b/aeppl/__init__.py
@@ -4,7 +4,13 @@ __version__ = get_versions()["version"]
 del get_versions
 
 
-from .logprob import logprob  # isort: split
+from aeppl.logprob import logprob  # isort: split
 
-from .joint_logprob import joint_logprob
-from .printing import latex_pprint, pprint
+from aeppl.joint_logprob import joint_logprob
+from aeppl.printing import latex_pprint, pprint
+
+# isort: off
+# Add optimizations to the DBs
+import aeppl.mixture
+
+# isort: on

--- a/aeppl/joint_logprob.py
+++ b/aeppl/joint_logprob.py
@@ -13,7 +13,7 @@ from aesara.tensor.random.op import RandomVariable
 from aesara.tensor.var import TensorVariable
 
 from aeppl.logprob import _logprob
-from aeppl.opt import PreserveRVMappings, logprob_canonicalize
+from aeppl.opt import PreserveRVMappings, logprob_rewrites_db
 from aeppl.utils import rvs_to_value_vars
 
 
@@ -107,7 +107,7 @@ def joint_logprob(
 
     fgraph.attach_feature(rv_remapper)
 
-    logprob_canonicalize.query(OptimizationQuery(include=["basic"])).optimize(fgraph)
+    logprob_rewrites_db.query(OptimizationQuery(include=["basic"])).optimize(fgraph)
 
     if extra_rewrites is not None:
         extra_rewrites.optimize(fgraph)

--- a/aeppl/mixture.py
+++ b/aeppl/mixture.py
@@ -1,0 +1,240 @@
+from typing import List, Optional
+
+import aesara.tensor as at
+import numpy as np
+from aesara.compile.builders import OpFromGraph
+from aesara.graph.basic import Apply
+from aesara.graph.fg import FunctionGraph
+from aesara.graph.opt import local_optimizer, pre_greedy_local_optimizer
+from aesara.ifelse import ifelse
+from aesara.tensor.basic import Join, MakeVector
+from aesara.tensor.random.op import RandomVariable
+from aesara.tensor.random.opt import local_dimshuffle_rv_lift, local_subtensor_rv_lift
+from aesara.tensor.shape import shape_tuple
+from aesara.tensor.type_other import NoneConst
+from aesara.tensor.var import TensorVariable
+
+from aeppl.logprob import _logprob, logprob
+from aeppl.opt import naive_bcast_rv_lift, rv_sinking_db, subtensor_ops
+from aeppl.utils import get_constant_value, indices_from_subtensor
+
+
+def rv_pull_down(x: TensorVariable, dont_touch_vars=None) -> TensorVariable:
+    """Pull a ``RandomVariable`` ``Op`` down through a graph, when possible."""
+    fgraph = FunctionGraph(outputs=dont_touch_vars or [], clone=False)
+
+    return pre_greedy_local_optimizer(
+        fgraph,
+        [
+            local_dimshuffle_rv_lift,
+            local_subtensor_rv_lift,
+            naive_bcast_rv_lift,
+        ],
+        x,
+    )
+
+
+class MixtureRV(OpFromGraph):
+    """A placeholder used to specify a log-likelihood for a mixture sub-graph."""
+
+    default_output = 1
+    # FIXME: This is just to appease `random_make_inplace`
+    inplace = True
+
+    @classmethod
+    def create_node(cls, node, indices, mixture_rvs):
+        out_var = node.default_output()
+
+        inputs = list(indices) + list(mixture_rvs)
+
+        mixture_op = cls(
+            # The first and third parameters are simply placeholders so that the
+            # arguments signature matches `RandomVariable`'s
+            inputs,
+            [NoneConst, out_var],
+            inline=True,
+            on_unused_input="ignore",
+        )
+
+        # Give this composite `Op` a `RandomVariable`-like interface
+        mixture_op.name = f"{out_var.name if out_var.name else ''}-mixture"
+        mixture_op.ndim_supp = out_var.ndim
+        mixture_op.dtype = out_var.dtype
+        mixture_op.ndims_params = [inp.ndim for inp in inputs]
+
+        # new_node = mixture_op.make_node(None, None, None, *inputs)
+        new_node = mixture_op(*inputs)
+
+        return new_node.owner
+
+    def make_node(self, *inputs):
+        # Make the `make_node` signature consistent with the node inputs
+        # TODO: This is a hack; make it less so.
+        num_expected_inps = len(self.local_inputs) - len(self.shared_inputs)
+        return super().make_node(*inputs[:num_expected_inps])
+
+    def rng_fn(self, rng, *args, **kwargs):
+        raise NotImplementedError()
+
+    def get_non_shared_inputs(self, inputs):
+        return inputs[: len(self.shared_inputs)]
+
+
+# Allow `MixtureRV`s to be typed as `RandomVariable`s
+RandomVariable.register(MixtureRV)
+
+
+def get_stack_mixture_vars(
+    node: Apply,
+) -> Optional[List[TensorVariable]]:
+    r"""Extract the mixture terms from a `*Subtensor*` applied to stacked `RandomVariable`\s."""
+    if not isinstance(node.op, subtensor_ops):
+        return  # noqa
+
+    joined_rvs = node.inputs[0]
+
+    # First, make sure that it's some sort of concatenation
+    if not (joined_rvs.owner and isinstance(joined_rvs.owner.op, (MakeVector, Join))):
+        # Node is not a compatible join `Op`
+        return  # noqa
+
+    if isinstance(joined_rvs.owner.op, MakeVector):
+        mixture_rvs = joined_rvs.owner.inputs
+
+    elif isinstance(joined_rvs.owner.op, Join):
+        mixture_rvs = joined_rvs.owner.inputs[1:]
+        join_axis = joined_rvs.owner.inputs[0]
+        try:
+            join_axis = int(get_constant_value(join_axis))
+        except ValueError:
+            # TODO: Support symbolic join axes
+            return
+
+        if join_axis != 0:
+            # TODO: Support other join axes
+            return
+
+    if not all(
+        rv.owner and isinstance(rv.owner.op, RandomVariable) for rv in mixture_rvs
+    ):
+        # Currently, all mixture components must be `RandomVariable` outputs
+        # TODO: Allow constants and make them Dirac-deltas
+        return
+
+    return mixture_rvs
+
+
+@local_optimizer(subtensor_ops)
+def mixture_replace(fgraph, node):
+    r"""Identify mixture sub-graphs and replace them with a place-holder `Op`.
+
+    The basic idea is to find ``stack(mixture_comps)[I_rv]``, where
+    ``mixture_comps`` is a ``list`` of `RandomVariable`\s and ``I_rv`` is a
+    `RandomVariable` with a discrete and finite support.
+    From these terms, new terms ``Z_rv[i] = mixture_comps[i][i == I_rv]`` are
+    created for each ``i`` in ``enumerate(mixture_comps)``.
+    """
+
+    rv_map_feature = getattr(fgraph, "preserve_rv_mappings", None)
+
+    if rv_map_feature is None:
+        return  # noqa
+
+    out_var = node.default_output()
+
+    if out_var not in rv_map_feature.rv_values:
+        return
+
+    mixture_res = get_stack_mixture_vars(node)
+
+    if mixture_res is None:
+        return
+
+    mixture_rvs = mixture_res
+
+    mixture_value_var = rv_map_feature.rv_values.pop(out_var, None)
+
+    # We loop through mixture components and collect all the array elements
+    # that belong to each one (by way of their indices).
+    for i, component_rv in enumerate(mixture_rvs):
+        if component_rv in rv_map_feature.rv_values:
+            raise ValueError("A value variable was specified for a mixture component")
+        component_rv.tag.ignore_logprob = True
+
+    # Replace this sub-graph with a `MixtureRV`
+    new_node = MixtureRV.create_node(node, node.inputs[1:], mixture_rvs)
+
+    new_mixture_rv = new_node.default_output()
+    new_mixture_rv.name = "mixture"
+    rv_map_feature.rv_values[new_mixture_rv] = mixture_value_var
+
+    # FIXME: This is pretty hackish
+    fgraph.import_node(new_node, import_missing=True, reason="mixture_rv")
+
+    return [new_mixture_rv]
+
+
+@_logprob.register(MixtureRV)
+def logprob_MixtureRV(op, value, *inputs, name=None, **kwargs):
+    inputs = op.get_non_shared_inputs(inputs)
+
+    subtensor_node = op.outputs[1].owner
+    num_indices = len(subtensor_node.inputs) - 1
+    indices = inputs[:num_indices]
+    indices = indices_from_subtensor(
+        getattr(subtensor_node.op, "idx_list", None), indices
+    )
+    comp_rvs = inputs[num_indices:]
+
+    if value.ndim > 0:
+        # TODO: Make the join axis to the left-most dimension (or transpose the
+        # problem)
+        join_axis = 0  # op.join_axis
+
+        value_shape = shape_tuple(value)
+        logp_val = at.full(value_shape, -np.inf, dtype=value.dtype)
+
+        for i, comp_rv in enumerate(comp_rvs):
+            I_0 = indices[join_axis]
+            join_indices = at.nonzero(at.eq(I_0, i))
+            #
+            # pre_index = (
+            #     tuple(at.ogrid[tuple(slice(None, s) for s in at.shape(join_indices))])
+            #     if I_0 is not None
+            #     else (slice(None),)
+            # )
+            #
+            # non_join_indices = pre_index + indices[1:]
+            #
+            # obs_i = value[join_indices][non_join_indices]
+            obs_i = value[join_indices]
+
+            comp_shape = shape_tuple(comp_rv)
+            bcast_shape = at.broadcast_shape(
+                value_shape, comp_shape, arrays_are_shapes=True
+            )
+            bcasted_comp_rv = at.broadcast_to(comp_rv, bcast_shape)
+            zz = bcasted_comp_rv[join_indices]
+            indexed_comp_rv = rv_pull_down(zz, inputs)
+            # indexed_comp_rv = rv_pull_down(indexed_comp_rv[non_join_indices], inputs)
+
+            logp_val = at.set_subtensor(
+                # logp_val[join_indices][non_join_indices],
+                logp_val[join_indices],
+                logprob(indexed_comp_rv, obs_i),
+            )
+
+    else:
+        logp_val = 0.0
+        for i, comp_rv in enumerate(comp_rvs):
+            comp_logp = logprob(comp_rv, value)
+            logp_val += ifelse(
+                at.eq(indices[0], i),
+                comp_logp,
+                at.as_tensor(0.0, dtype=comp_logp.dtype),
+            )
+
+    return logp_val
+
+
+rv_sinking_db.register("mixture_replace", mixture_replace, -5, "basic")

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "numpy>=1.18.1",
         "scipy>=1.4.0",
         "numba",
-        "aesara >= 2.0.12",
+        "aesara >= 2.1.1",
     ],
     tests_require=["pytest"],
     long_description=open("README.md").read() if exists("README.md") else "",

--- a/tests/test_joint_logprob.py
+++ b/tests/test_joint_logprob.py
@@ -181,3 +181,20 @@ def test_persist_inputs():
     logp = joint_logprob(y_rv, {beta_rv: beta, y_rv: y})
 
     assert x in ancestors([logp])
+
+
+def test_ignore_logprob():
+    x = at.scalar("x")
+    beta_rv = at.random.normal(0, 1, name="beta")
+    beta_rv.tag.ignore_logprob = True
+    y_rv = at.random.normal(beta_rv * x, 1, name="y")
+
+    beta = beta_rv.type()
+    y = y_rv.type()
+
+    logp = joint_logprob(y_rv, {beta_rv: beta, y_rv: y})
+
+    y_rv_2 = at.random.normal(beta * x, 1, name="y")
+    logp_exp = joint_logprob(y_rv_2, {y_rv_2: y})
+
+    assert equal_computations([logp], [logp_exp])

--- a/tests/test_mixture.py
+++ b/tests/test_mixture.py
@@ -1,0 +1,191 @@
+import aesara
+import aesara.tensor as at
+import numpy as np
+import pytest
+import scipy.stats.distributions as sp
+from aesara.graph.basic import Variable
+
+from aeppl.joint_logprob import joint_logprob
+from tests.utils import assert_no_rvs
+
+
+def test_mixture_basics():
+    srng = at.random.RandomStream(29833)
+
+    def create_mix_model(size, axis):
+        X_rv = srng.normal(0, 1, size=size, name="X")
+        Y_rv = srng.gamma(0.5, 0.5, size=size, name="Y")
+
+        p_at = at.scalar("p")
+        p_at.tag.test_value = 0.5
+
+        I_rv = srng.bernoulli(p_at, size=size, name="I")
+        i_vv = I_rv.clone()
+        i_vv.name = "i"
+
+        if isinstance(axis, Variable):
+            M_rv = at.join(axis, X_rv, Y_rv)[I_rv]
+        else:
+            M_rv = at.stack([X_rv, Y_rv], axis=axis)[I_rv]
+
+        M_rv.name = "M"
+        m_vv = M_rv.clone()
+        m_vv.name = "m"
+
+        return locals()
+
+    with pytest.raises(ValueError, match=".*value variable was specified.*"):
+        env = create_mix_model(None, 0)
+        X_rv = env["X_rv"]
+        I_rv = env["I_rv"]
+        i_vv = env["i_vv"]
+        M_rv = env["M_rv"]
+        m_vv = env["m_vv"]
+
+        x_vv = X_rv.clone()
+        x_vv.name = "x"
+
+        joint_logprob(M_rv, {M_rv: m_vv, I_rv: i_vv, X_rv: x_vv})
+
+    with pytest.raises(NotImplementedError):
+        env = create_mix_model((2,), 1)
+        I_rv = env["I_rv"]
+        i_vv = env["i_vv"]
+        M_rv = env["M_rv"]
+        m_vv = env["m_vv"]
+        joint_logprob(M_rv, {M_rv: m_vv, I_rv: i_vv})
+
+    with pytest.raises(NotImplementedError):
+        axis_at = at.lscalar("axis")
+        axis_at.tag.test_value = 0
+        env = create_mix_model((2,), axis_at)
+        I_rv = env["I_rv"]
+        i_vv = env["i_vv"]
+        M_rv = env["M_rv"]
+        m_vv = env["m_vv"]
+        joint_logprob(M_rv, {M_rv: m_vv, I_rv: i_vv})
+
+
+@pytest.mark.parametrize(
+    "p_val, size",
+    [
+        (np.array(0.0, dtype=aesara.config.floatX), ()),
+        (np.array(1.0, dtype=aesara.config.floatX), ()),
+        (np.array(0.0, dtype=aesara.config.floatX), (2,)),
+        (np.array(1.0, dtype=aesara.config.floatX), (2, 1)),
+    ],
+)
+@aesara.config.change_flags(compute_test_value="raise")
+def test_hetero_mixture_scalar(p_val, size):
+    srng = at.random.RandomStream(29833)
+
+    X_rv = srng.normal(0, 1, size=size, name="X")
+    Y_rv = srng.gamma(0.5, 0.5, size=size, name="Y")
+
+    p_at = at.scalar("p")
+    p_at.tag.test_value = p_val
+
+    I_rv = srng.bernoulli(p_at, size=size, name="I")
+    i_vv = I_rv.clone()
+    i_vv.name = "i"
+
+    M_rv = at.stack([X_rv, Y_rv])[I_rv]
+    M_rv.name = "M"
+    m_vv = M_rv.clone()
+    m_vv.name = "m"
+
+    M_logp = joint_logprob(M_rv, {M_rv: m_vv, I_rv: i_vv})
+
+    M_logp_fn = aesara.function([p_at, m_vv, i_vv], M_logp)
+
+    # The compiled graph should not contain any `RandomVariables`
+    assert_no_rvs(M_logp_fn.maker.fgraph.outputs[0])
+
+    decimals = 6 if aesara.config.floatX == "float64" else 4
+
+    test_val_rng = np.random.RandomState(3238)
+
+    bern_sp = sp.bernoulli(p_val)
+    norm_sp = sp.norm(loc=0, scale=1)
+    gamma_sp = sp.gamma(0.5, scale=1.0 / 0.5)
+
+    for i in range(10):
+        i_val = bern_sp.rvs(size=size, random_state=test_val_rng)
+        x_val = norm_sp.rvs(size=size, random_state=test_val_rng)
+        y_val = gamma_sp.rvs(size=size, random_state=test_val_rng)
+
+        m_val = np.stack([x_val, y_val])[i_val]
+        exp_obs_logps = np.stack([norm_sp.logpdf(x_val), gamma_sp.logpdf(y_val)])[i_val]
+
+        exp_obs_logps += bern_sp.logpmf(i_val)
+
+        logp_vals = M_logp_fn(p_val, m_val, i_val)
+
+        np.testing.assert_almost_equal(logp_vals, exp_obs_logps, decimal=decimals)
+
+
+@pytest.mark.parametrize(
+    "p_val, size",
+    [
+        # (np.array(0.0, dtype=aesara.config.floatX), ()),
+        # (np.array(1.0, dtype=aesara.config.floatX), ()),
+        # (np.array(0.0, dtype=aesara.config.floatX), (2,)),
+        # (np.array(1.0, dtype=aesara.config.floatX), (2, 1)),
+        # (np.array(1.0, dtype=aesara.config.floatX), (2, 3)),
+        (np.array([0.1, 0.9], dtype=aesara.config.floatX), (2, 3)),
+    ],
+)
+def test_hetero_mixture_nonscalar(p_val, size):
+    srng = at.random.RandomStream(29833)
+
+    X_rv = srng.normal(0, 1, size=size, name="X")
+    Y_rv = srng.gamma(0.5, 0.5, size=size, name="Y")
+
+    if np.ndim(p_val) == 0:
+        p_at = at.scalar("p")
+        p_at.tag.test_value = p_val
+
+        I_rv = srng.bernoulli(p_at, size=size, name="I")
+    else:
+        p_at = at.vector("p")
+        p_at.tag.test_value = np.array(p_val, dtype=aesara.config.floatX)
+        I_rv = srng.categorical(p_at, size=size, name="I")
+        p_val_1 = p_val[1]
+
+    i_vv = I_rv.clone()
+    i_vv.name = "i"
+
+    M_rv = at.stack([X_rv, Y_rv])[I_rv]
+    M_rv.name = "M"
+
+    m_vv = M_rv.clone()
+    m_vv.name = "m"
+
+    M_logp = joint_logprob(M_rv, {M_rv: m_vv, I_rv: i_vv})
+
+    M_logp_fn = aesara.function([p_at, m_vv, i_vv], M_logp)
+
+    assert_no_rvs(M_logp_fn.maker.fgraph.outputs[0])
+
+    decimals = 6 if aesara.config.floatX == "float64" else 4
+
+    test_val_rng = np.random.RandomState(3238)
+
+    bern_sp = sp.bernoulli(p_val_1)
+    norm_sp = sp.norm(loc=0, scale=1)
+    gamma_sp = sp.gamma(0.5, scale=1.0 / 0.5)
+
+    for i in range(10):
+        i_val = bern_sp.rvs(size=size, random_state=test_val_rng)
+        x_val = norm_sp.rvs(size=size, random_state=test_val_rng)
+        y_val = gamma_sp.rvs(size=size, random_state=test_val_rng)
+
+        exp_obs_logps = np.stack([norm_sp.logpdf(x_val), gamma_sp.logpdf(y_val)])[i_val]
+
+        m_val = np.stack([x_val, y_val])[i_val]
+
+        exp_obs_logps += bern_sp.logpmf(i_val)
+
+        logp_vals = M_logp_fn(p_val, m_val, i_val)
+
+        np.testing.assert_almost_equal(logp_vals, exp_obs_logps, decimal=decimals)


### PR DESCRIPTION
This PR implements log-probabilities for general mixtures (e.g. heterogeneous `RandomVariable`s).

This implementation does not produce a **marginalized** log-probability.

It covers cases like the following:
```python
import aesara.tensor as at

from aeppl import joint_logprob


X_rv = at.random.normal(0, 1, name="X")
Y_rv = at.random.gamma(0.5, 0.5, name="Y")

p = at.scalar("p")
I_rv = at.random.bernoulli(p, name="I")

M_rv = at.stack([X_rv, Y_rv])[I_rv]

m = M_rv.type()
M_logp = joint_logprob(M_rv, {M_rv: m})
```

Instead of producing a log-probability graph that represents the computation `np.stack([logprob(X, obs), logprob(Y, obs)])[idx]`, which requires complete evaluation of `logprob(X, obs)` and `logprob(Y, obs)` even though `idx` will only select _some_ of those `logprob` values from each mixture component, this implementation will compute something like the following:
```python
res[idx == 0] = logprob(X[idx == 0], obs[idx == 0])
res[idx == 1] = logprob(Y[idx == 1], obs[idx == 1])
```

~Currently, it does all the necessary setup and parsing needed to construct the desired log-probability graphs; however, the actual construction steps aren't necessarily finished.  I still need to check/confirm a few things and&mdash;obviously&mdash;write tests.~