### PR TITLE
Implement chained transforms

### DIFF
--- a/aeppl/__init__.py
+++ b/aeppl/__init__.py
@@ -14,6 +14,7 @@ from aeppl.printing import latex_pprint, pprint
 import aeppl.cumsum
 import aeppl.mixture
 import aeppl.scan
+import aeppl.transforms
 import aeppl.truncation
 
 # isort: on


### PR DESCRIPTION
Closes #18.

TODO:
- [x] Nested transforms for graphs involving a base `RV` and the following ops: `Add`, `Mul`, `Exp`, `Log`
- [x] Deal with base RVs containing size dimensions of `1` and generic loc / shift tensors (see https://github.com/aesara-devs/aeppl/pull/26#issuecomment-900945477)
- [x] ~~Deal properly with broadcasting as discussed in https://github.com/aesara-devs/aeppl/pull/22#issuecomment-875349807~~ deferred to https://github.com/aesara-devs/aeppl/discussions/51
- [x] ~~Deal with discrete variables (either do not allow or do not add jacobian term)~~ Not allowed for now.
- [x] ~~Jacobian of ChainTransform is wonky for non-scalar variables~~ Loc transform was returning a scalar `det`
- [x] Add comprehensive tests
- [x] More transforms can be added later by just expanding the rewrite