### PR TITLE
Replace `RandomVariable` with `MeasurableVariable` abstraction

### DIFF
--- a/aeppl/abstract.py
+++ b/aeppl/abstract.py
@@ -1,0 +1,22 @@
+import abc
+from functools import singledispatch
+
+from aesara.tensor.random.op import RandomVariable
+
+
+class MeasurableVariable(abc.ABC):
+    """A variable that can be assigned a measure/log-probability"""
+
+
+MeasurableVariable.register(RandomVariable)
+
+
+@singledispatch
+def get_measurable_outputs(op, node):
+    """Return only the outputs that are measurable."""
+    return node.outputs
+
+
+@get_measurable_outputs.register(RandomVariable)
+def randomvariable_moutputs(op, node):
+    return node.outputs[1:]


### PR DESCRIPTION
This PR replaces the use of the `RandomVariable`  with a `MeasurableVariable` type as the means of assigning log-probabilities to graphs nodes.