### PR TITLE
Transform fix

### DIFF
--- a/aeppl/transforms.py
+++ b/aeppl/transforms.py
@@ -192,6 +192,10 @@ class LogOddsTransform(RVTransform):
     def forward(self, value, *inputs):
         return at.log(value / (1 - value))
 
+    def log_jac_det(self, value, *inputs):
+        sigmoid_value = at.sigmoid(value)
+        return at.log(sigmoid_value) + at.log1p(-sigmoid_value)
+
 
 class StickBreaking(RVTransform):
     name = "stickbreaking"

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -7,7 +7,7 @@ from aesara.graph.opt import in2out
 from numdifftools import Jacobian
 
 from aeppl.joint_logprob import joint_logprob
-from aeppl.transforms import _transformed_rv, transform_logprob
+from aeppl.transforms import _default_transformed_rv, default_transform
 
 
 @pytest.mark.parametrize(
@@ -49,11 +49,8 @@ from aeppl.transforms import _transformed_rv, transform_logprob
         pytest.param(
             at.random.lognormal,
             (-1.5, 10.5),
-            lambda mu, sigma: sp.stats.lognorm(s=sigma, scale=np.exp(mu)),
+            lambda mu, sigma: sp.stats.lognorm(s=sigma, loc=0, scale=np.exp(mu)),
             (),
-            marks=pytest.mark.xfail(
-                reason=("Need to figure out what's going on here.")
-            ),
         ),
         (
             at.random.lognormal,
@@ -142,7 +139,7 @@ def test_transformed_logprob(at_dist, dist_params, sp_dist, size):
     b_value_var = b.clone()
     b_value_var.name = "b_value"
 
-    transform_opt = in2out(transform_logprob, ignore_newtrees=True)
+    transform_opt = in2out(default_transform, ignore_newtrees=True)
     res = joint_logprob(
         b, {a: a_value_var, b: b_value_var}, extra_rewrites=transform_opt
     )
@@ -152,7 +149,7 @@ def test_transformed_logprob(at_dist, dist_params, sp_dist, size):
     decimals = 6 if aesara.config.floatX == "float64" else 4
     logp_vals_fn = aesara.function([a_value_var, b_value_var], res)
 
-    a_trans_op = _transformed_rv(a.owner.op, a.owner).op
+    a_trans_op = _default_transformed_rv(a.owner.op, a.owner).op
     transform = a_trans_op.transform
 
     a_forward_fn = aesara.function(
@@ -172,18 +169,31 @@ def test_transformed_logprob(at_dist, dist_params, sp_dist, size):
 
         exp_logprob_val = a_dist.logpdf(a_val)
 
+        a_trans_value = a_forward_fn(a_val)
         if a_val.ndim > 0:
             # exp_logprob_val = np.vectorize(a_dist.logpdf, signature="(n)->()")(a_val)
-            jacobian_val = Jacobian(a_backward_fn)(a_val)[:-1]
+            jacobian_val = Jacobian(a_backward_fn)(a_trans_value)[:-1]
         else:
             jacobian_val = np.atleast_2d(
-                sp.misc.derivative(a_backward_fn, a_val, dx=1e-6)
+                sp.misc.derivative(a_backward_fn, a_trans_value, dx=1e-6)
             )
 
         exp_logprob_val += np.log(np.linalg.det(jacobian_val))
         exp_logprob_val += b_dist.logpdf(b_val)
 
-        a_trans_value = a_forward_fn(a_val)
         logprob_val = logp_vals_fn(a_trans_value, b_val)
 
         np.testing.assert_almost_equal(exp_logprob_val, logprob_val, decimal=decimals)
+
+
+def test_simple_transformed_logprob():
+    x_rv = at.random.halfnormal(0, 3, name="x_rv")
+    x = x_rv.clone()
+
+    transform_opt = in2out(default_transform, ignore_newtrees=True)
+    tr_logp = joint_logprob(x_rv, {x_rv: x}, extra_rewrites=transform_opt)
+
+    assert np.isclose(
+        tr_logp.eval({x: np.log(2.5)}),
+        sp.stats.halfnorm(0, 3).logpdf(2.5) + np.log(2.5),
+    )


### PR DESCRIPTION
This PR fixes an inconsistency in the `transformed_logprob`. The jacobian should be computed from the original forward transformed value, but due to the synchronous replacements in `joint_logprob` it was being computed from the backward transformed value.

On PyMC3 V3, these lines show that the jacobian is computed on the original transformed value, whereas the logp is computed on the untransformed value: https://github.com/pymc-devs/pymc3/blob/10c914b92c649b018be09e6dab5a5bc905d4f41e/pymc3/distributions/transforms.py#L177-L197

~~I still have to check if V4 is handling this well.~~ In V4, it's working fine because the original `value_vars` are passed directly to the jacobian method when collecting the logp terms, and only the `rvs` are subsequently replaced by the back-transformed `value_vars`:

https://github.com/pymc-devs/pymc3/blob/bb253c5f464b80c14b6a52529c26b5e72358b879/pymc3/distributions/logprob.py#L218

I added a simple numerical test that passes in this PR but fails in main. 

Also added a `log_jac_det` method to the `logodds` transform and a test for the fallback method in the super `RVTransform` class