### PR TITLE
Enforce value support in Vonmises logprob

### DIFF
--- a/aeppl/logprob.py
+++ b/aeppl/logprob.py
@@ -238,10 +238,9 @@ def weibull_logprob(op, value, *inputs, **kwargs):
 def vonmises_logprob(op, value, *inputs, **kwargs):
     mu, kappa = inputs[3:]
     res = kappa * at.cos(mu - value) - at.log(2 * np.pi) - at.log(at.i0(kappa))
-    # This doesn't match `scipy.stats.vonmises.logpdf`:
-    # res = at.switch(
-    #     at.bitwise_and(at.ge(value, -np.pi), at.le(value, np.pi)), res, -np.inf
-    # )
+    res = at.switch(
+        at.bitwise_and(at.ge(value, -np.pi), at.le(value, np.pi)), res, -np.inf
+    )
     res = Assert("kappa > 0")(res, at.all(at.gt(kappa, 0.0)))
     return res
 

--- a/tests/test_logprob.py
+++ b/tests/test_logprob.py
@@ -390,10 +390,20 @@ def test_weibull_logprob(dist_params, obs, size, error):
 @pytest.mark.parametrize(
     "dist_params, obs, size, error",
     [
-        ((-1, -1.0), np.array([0, 0.5, 1, 10, -1], dtype=np.float64), (), True),
-        ((1.5, 10.5), np.array([0, 0.5, 1, 10, -1], dtype=np.float64), (), False),
-        ((1.5, 2.0), np.array([0, 0.5, 1, 10, -1], dtype=np.float64), (2, 3), False),
-        ((10, 1.0), np.array([0, 0.5, 1, 10, -1], dtype=np.float64), (), False),
+        ((-1, -1.0), np.array([-np.pi, -0.5, 0, 1, np.pi], dtype=np.float64), (), True),
+        (
+            (1.5, 10.5),
+            np.array([-np.pi, -0.5, 0, 1, np.pi], dtype=np.float64),
+            (),
+            False,
+        ),
+        (
+            (1.5, 2.0),
+            np.array([-np.pi, -0.5, 0, 1, np.pi], dtype=np.float64),
+            (2, 3),
+            False,
+        ),
+        ((10, 1.0), np.array([-np.pi, -0.5, 0, 1, np.pi], dtype=np.float64), (), False),
     ],
 )
 def test_vonmises_logprob(dist_params, obs, size, error):


### PR DESCRIPTION
Closes #2

`Scipy`'s Vonmises distribution is incoherent (see https://github.com/scipy/scipy/issues/4598). The pdf is valid on the entire real line, whereas random draws are simply shifted from the interval `[-pi, pi]` to `[-pi+mu, pi+mu]` (there is no way they could generate samples on the real line).

In contrast, `Numpy`s Vonmises draws are always contained within the `[-pi, pi]` interval, which corresponds to the `PyMC3`'s logp (and `Scipy`'s if you truncate the value support). We use `Numpy`'s generator in `Aesara`.

I made a small gist that illustrates this: https://gist.github.com/ricardoV94/54086f08f078c35ac2a8e1943e2cba55

It seems better that our logprob graph match the generative graph, so we should enforce the `value` support. This is not a real limitation since we can add the `Circular` and `Affine` transformations anyway.