### PR TITLE
Allow multiple variable arguments to joint_logprob

### DIFF
--- a/aeppl/joint_logprob.py
+++ b/aeppl/joint_logprob.py
@@ -1,6 +1,6 @@
 import warnings
 from collections import deque
-from typing import Dict, Optional, Union
+from typing import Dict, Iterable, Optional, Union
 
 from aesara import config
 from aesara.graph.basic import graph_inputs, io_toposort
@@ -18,7 +18,7 @@ from aeppl.utils import rvs_to_value_vars
 
 
 def joint_logprob(
-    var: TensorVariable,
+    vars: Union[TensorVariable, Iterable[TensorVariable]],
     rv_values: Dict[TensorVariable, TensorVariable],
     warn_missing_rvs: bool = True,
     extra_rewrites: Optional[Union[GlobalOptimizer, LocalOptimizer]] = None,
@@ -60,10 +60,12 @@ def joint_logprob(
 
     Parameters
     ==========
-    var
-        The graph containing the stochastic/`RandomVariable` elements for
+    vars
+        The graphs containing the stochastic/`RandomVariable` elements for
         which we want to compute a joint log-probability.  This graph
-        effectively represents a statistical model.
+        effectively represents a statistical model.  When multiple elements are
+        given, their log-probabilities are summed, producing their joint
+        log-probability.
     rv_values
         A ``dict`` of variables that maps stochastic elements
         (e.g. `RandomVariable`\s) to symbolic `Variable`\s representing their
@@ -77,6 +79,9 @@ def joint_logprob(
         etc.)
 
     """
+    if isinstance(vars, TensorVariable):
+        vars = [vars]
+
     # Since we're going to clone the entire graph, we need to keep a map from
     # the old nodes to the new ones; otherwise, we won't be able to use
     # `rv_values`.
@@ -89,7 +94,7 @@ def joint_logprob(
     # to give good warnings when an unaccounted for `RandomVariable` is
     # encountered
     fgraph = FunctionGraph(
-        outputs=[var],
+        outputs=vars,
         clone=True,
         memo=memo,
         copy_orphans=False,

--- a/tests/test_joint_logprob.py
+++ b/tests/test_joint_logprob.py
@@ -75,6 +75,31 @@ def test_joint_logprob_basic():
     assert a_value_var in res_ancestors
 
 
+def test_joint_logprob_multi_obs():
+
+    a = at.random.uniform(0.0, 1.0)
+    b = at.random.normal(0.0, 1.0)
+
+    a_val = a.clone()
+    b_val = b.clone()
+
+    logp = joint_logprob((a, b), {a: a_val, b: b_val})
+    logp_exp = logprob(a, a_val) + logprob(b, b_val)
+
+    assert equal_computations([logp], [logp_exp])
+
+    x = at.random.normal(0, 1)
+    y = at.random.normal(x, 1)
+
+    x_val = x.clone()
+    y_val = y.clone()
+
+    logp = joint_logprob([x, y], {x: x_val, y: y_val})
+    exp_logp = joint_logprob([y], {x: x_val, y: y_val})
+
+    assert equal_computations([logp], [exp_logp])
+
+
 @pytest.mark.parametrize(
     "indices, size",
     [


### PR DESCRIPTION
This PR enables multiple variable arguments (e.g. observed variables) in `joint_logprob`.

Closes #40.