### PR TITLE
Create factorized `joint_logprob`

### DIFF
--- a/aeppl/__init__.py
+++ b/aeppl/__init__.py
@@ -6,7 +6,7 @@ del get_versions
 
 from aeppl.logprob import logprob  # isort: split
 
-from aeppl.joint_logprob import joint_logprob
+from aeppl.joint_logprob import factorized_joint_logprob, joint_logprob
 from aeppl.printing import latex_pprint, pprint
 
 # isort: off

--- a/aeppl/joint_logprob.py
+++ b/aeppl/joint_logprob.py
@@ -35,15 +35,15 @@ def joint_logprob(
 
         import aesara.tensor as at
 
-        Y_rv = at.random.normal(0, at.sqrt(sigma2_rv))
         sigma2_rv = at.random.invgamma(0.5, 0.5)
+        Y_rv = at.random.normal(0, at.sqrt(sigma2_rv))
 
     This graph for ``Y_rv`` is equivalent to the following hierarchical model:
 
     .. math::
 
-        Y \sim& \operatorname{N}(0, \sigma^2) \\
-        \sigma^2 \sim& \operatorname{InvGamma}(0.5, 0.5)
+        \sigma^2 \sim& \operatorname{InvGamma}(0.5, 0.5) \\
+        Y \sim& \operatorname{N}(0, \sigma^2)
 
     If we create a value variable for ``Y_rv``, i.e. ``y = at.scalar("y")``,
     the graph of ``joint_logprob(Y_rv, {Y_rv: y})`` is equivalent to the

--- a/tests/test_joint_logprob.py
+++ b/tests/test_joint_logprob.py
@@ -286,3 +286,14 @@ def test_ignore_logprob_multiout():
     logp_exp = joint_logprob(Y_1_rv, {Y_1_rv: y_1_vv, Y_2_rv: y_2_vv})
 
     assert logp_exp is None
+
+
+def test_multiple_rvs_to_same_value_raises():
+    x_rv1 = at.random.normal(name="x1")
+    x_rv2 = at.random.normal(name="x2")
+    x = x_rv1.type()
+    x.name = "x"
+
+    msg = "More than one logprob factor was assigned to the value var x"
+    with pytest.raises(ValueError, match=msg):
+        joint_logprob([x_rv1, x_rv2], {x_rv1: x, x_rv2: x})

--- a/tests/test_mixture.py
+++ b/tests/test_mixture.py
@@ -94,7 +94,7 @@ def test_hetero_mixture_scalar(p_val, size):
     m_vv = M_rv.clone()
     m_vv.name = "m"
 
-    M_logp = joint_logprob(M_rv, {M_rv: m_vv, I_rv: i_vv})
+    M_logp = joint_logprob(M_rv, {M_rv: m_vv, I_rv: i_vv}, sum=False)
 
     M_logp_fn = aesara.function([p_at, m_vv, i_vv], M_logp)
 
@@ -115,11 +115,8 @@ def test_hetero_mixture_scalar(p_val, size):
         y_val = gamma_sp.rvs(size=size, random_state=test_val_rng)
 
         m_val = np.stack([x_val, y_val])[i_val]
-
-        exp_obs_logps = np.stack([norm_sp.logpdf(x_val), gamma_sp.logpdf(y_val)])[
-            i_val
-        ].sum()
-        exp_obs_logps += bern_sp.logpmf(i_val).sum()
+        exp_obs_logps = np.stack([norm_sp.logpdf(x_val), gamma_sp.logpdf(y_val)])[i_val]
+        exp_obs_logps += bern_sp.logpmf(i_val)
 
         logp_vals = M_logp_fn(p_val, m_val, i_val)
 
@@ -163,7 +160,7 @@ def test_hetero_mixture_nonscalar(p_val, size):
     m_vv = M_rv.clone()
     m_vv.name = "m"
 
-    M_logp = joint_logprob(M_rv, {M_rv: m_vv, I_rv: i_vv})
+    M_logp = joint_logprob(M_rv, {M_rv: m_vv, I_rv: i_vv}, sum=False)
 
     M_logp_fn = aesara.function([p_at, m_vv, i_vv], M_logp)
 
@@ -182,10 +179,8 @@ def test_hetero_mixture_nonscalar(p_val, size):
         x_val = norm_sp.rvs(size=size, random_state=test_val_rng)
         y_val = gamma_sp.rvs(size=size, random_state=test_val_rng)
 
-        exp_obs_logps = np.stack([norm_sp.logpdf(x_val), gamma_sp.logpdf(y_val)])[
-            i_val
-        ].sum()
-        exp_obs_logps += bern_sp.logpmf(i_val).sum()
+        exp_obs_logps = np.stack([norm_sp.logpdf(x_val), gamma_sp.logpdf(y_val)])[i_val]
+        exp_obs_logps += bern_sp.logpmf(i_val)
 
         m_val = np.stack([x_val, y_val])[i_val]
         logp_vals = M_logp_fn(p_val, m_val, i_val)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -176,7 +176,7 @@ def test_transformed_logprob(at_dist, dist_params, sp_dist, size):
         b_dist = sp.stats.norm(a_val, 1.0)
         b_val = b_dist.rvs(random_state=test_val_rng).astype(b_value_var.dtype)
 
-        exp_logprob_val = a_dist.logpdf(a_val).sum()
+        exp_logprob_val = a_dist.logpdf(a_val)
 
         a_trans_value = a_forward_fn(a_val)
         if a_val.ndim > 0:
@@ -187,7 +187,7 @@ def test_transformed_logprob(at_dist, dist_params, sp_dist, size):
                 sp.misc.derivative(a_backward_fn, a_trans_value, dx=1e-6)
             )
 
-        exp_logprob_val += np.log(np.linalg.det(jacobian_val)).sum()
+        exp_logprob_val += np.log(np.linalg.det(jacobian_val))
         exp_logprob_val += b_dist.logpdf(b_val).sum()
 
         logprob_val = logp_vals_fn(a_trans_value, b_val)


### PR DESCRIPTION
The idea is that the core `joint_logprob` (here renamed to `factorized_joint_logprob`) would return a dictionary with `{value_var: logprob_term}` pairs, instead of adding them up as we currently do.

```python
import aesara.tensor as atr
from aeppl import factorized_joint_lopgrob

x_rv = atr.normal(name="x')
y_rv = atr.normal(x_rv, name="y")

factorized_joint_logprob(y_rv, {x_rv: x, y_rv: y})
```
```python
# returns
{
    y: normal_logprob(y, x, 1),
    x: normal_logprob(x, 0, 1),
}
```
CC @brandonwillard 