### PR TITLE
Remove vars argument from joint_logprob

### DIFF
--- a/aeppl/__init__.py
+++ b/aeppl/__init__.py
@@ -6,7 +6,7 @@ del get_versions
 
 from aeppl.logprob import logprob  # isort: split
 
-from aeppl.joint_logprob import joint_logprob
+from aeppl.joint_logprob import factorized_joint_logprob, joint_logprob
 from aeppl.printing import latex_pprint, pprint
 
 # isort: off

--- a/aeppl/joint_logprob.py
+++ b/aeppl/joint_logprob.py
@@ -35,15 +35,15 @@ def joint_logprob(
 
         import aesara.tensor as at
 
-        Y_rv = at.random.normal(0, at.sqrt(sigma2_rv))
         sigma2_rv = at.random.invgamma(0.5, 0.5)
+        Y_rv = at.random.normal(0, at.sqrt(sigma2_rv))
 
     This graph for ``Y_rv`` is equivalent to the following hierarchical model:
 
     .. math::
 
-        Y \sim& \operatorname{N}(0, \sigma^2) \\
-        \sigma^2 \sim& \operatorname{InvGamma}(0.5, 0.5)
+        \sigma^2 \sim& \operatorname{InvGamma}(0.5, 0.5) \\
+        Y \sim& \operatorname{N}(0, \sigma^2)
 
     If we create a value variable for ``Y_rv``, i.e. ``y = at.scalar("y")``,
     the graph of ``joint_logprob(Y_rv, {Y_rv: y})`` is equivalent to the

--- a/tests/test_joint_logprob.py
+++ b/tests/test_joint_logprob.py
@@ -286,3 +286,14 @@ def test_ignore_logprob_multiout():
     logp_exp = joint_logprob(Y_1_rv, {Y_1_rv: y_1_vv, Y_2_rv: y_2_vv})
 
     assert logp_exp is None
+
+
+def test_multiple_rvs_to_same_value_raises():
+    x_rv1 = at.random.normal(name="x1")
+    x_rv2 = at.random.normal(name="x2")
+    x = x_rv1.type()
+    x.name = "x"
+
+    msg = "More than one logprob factor was assigned to the value var x"
+    with pytest.raises(ValueError, match=msg):
+        joint_logprob([x_rv1, x_rv2], {x_rv1: x, x_rv2: x})

--- a/tests/test_mixture.py
+++ b/tests/test_mixture.py
@@ -45,7 +45,7 @@ def test_mixture_basics():
         x_vv = X_rv.clone()
         x_vv.name = "x"
 
-        joint_logprob(M_rv, {M_rv: m_vv, I_rv: i_vv, X_rv: x_vv})
+        joint_logprob({M_rv: m_vv, I_rv: i_vv, X_rv: x_vv})
 
     with pytest.raises(NotImplementedError):
         env = create_mix_model((2,), 1)
@@ -53,7 +53,7 @@ def test_mixture_basics():
         i_vv = env["i_vv"]
         M_rv = env["M_rv"]
         m_vv = env["m_vv"]
-        joint_logprob(M_rv, {M_rv: m_vv, I_rv: i_vv})
+        joint_logprob({M_rv: m_vv, I_rv: i_vv})
 
     with pytest.raises(NotImplementedError):
         axis_at = at.lscalar("axis")
@@ -63,7 +63,7 @@ def test_mixture_basics():
         i_vv = env["i_vv"]
         M_rv = env["M_rv"]
         m_vv = env["m_vv"]
-        joint_logprob(M_rv, {M_rv: m_vv, I_rv: i_vv})
+        joint_logprob({M_rv: m_vv, I_rv: i_vv})
 
 
 @pytest.mark.parametrize(
@@ -94,7 +94,7 @@ def test_hetero_mixture_scalar(p_val, size):
     m_vv = M_rv.clone()
     m_vv.name = "m"
 
-    M_logp = joint_logprob(M_rv, {M_rv: m_vv, I_rv: i_vv}, sum=False)
+    M_logp = joint_logprob({M_rv: m_vv, I_rv: i_vv}, sum=False)
 
     M_logp_fn = aesara.function([p_at, m_vv, i_vv], M_logp)
 
@@ -160,7 +160,7 @@ def test_hetero_mixture_nonscalar(p_val, size):
     m_vv = M_rv.clone()
     m_vv.name = "m"
 
-    M_logp = joint_logprob(M_rv, {M_rv: m_vv, I_rv: i_vv}, sum=False)
+    M_logp = joint_logprob({M_rv: m_vv, I_rv: i_vv}, sum=False)
 
     M_logp_fn = aesara.function([p_at, m_vv, i_vv], M_logp)
 

--- a/tests/test_mixture.py
+++ b/tests/test_mixture.py
@@ -94,7 +94,7 @@ def test_hetero_mixture_scalar(p_val, size):
     m_vv = M_rv.clone()
     m_vv.name = "m"
 
-    M_logp = joint_logprob(M_rv, {M_rv: m_vv, I_rv: i_vv})
+    M_logp = joint_logprob(M_rv, {M_rv: m_vv, I_rv: i_vv}, sum=False)
 
     M_logp_fn = aesara.function([p_at, m_vv, i_vv], M_logp)
 
@@ -115,11 +115,8 @@ def test_hetero_mixture_scalar(p_val, size):
         y_val = gamma_sp.rvs(size=size, random_state=test_val_rng)
 
         m_val = np.stack([x_val, y_val])[i_val]
-
-        exp_obs_logps = np.stack([norm_sp.logpdf(x_val), gamma_sp.logpdf(y_val)])[
-            i_val
-        ].sum()
-        exp_obs_logps += bern_sp.logpmf(i_val).sum()
+        exp_obs_logps = np.stack([norm_sp.logpdf(x_val), gamma_sp.logpdf(y_val)])[i_val]
+        exp_obs_logps += bern_sp.logpmf(i_val)
 
         logp_vals = M_logp_fn(p_val, m_val, i_val)
 
@@ -163,7 +160,7 @@ def test_hetero_mixture_nonscalar(p_val, size):
     m_vv = M_rv.clone()
     m_vv.name = "m"
 
-    M_logp = joint_logprob(M_rv, {M_rv: m_vv, I_rv: i_vv})
+    M_logp = joint_logprob(M_rv, {M_rv: m_vv, I_rv: i_vv}, sum=False)
 
     M_logp_fn = aesara.function([p_at, m_vv, i_vv], M_logp)
 
@@ -182,10 +179,8 @@ def test_hetero_mixture_nonscalar(p_val, size):
         x_val = norm_sp.rvs(size=size, random_state=test_val_rng)
         y_val = gamma_sp.rvs(size=size, random_state=test_val_rng)
 
-        exp_obs_logps = np.stack([norm_sp.logpdf(x_val), gamma_sp.logpdf(y_val)])[
-            i_val
-        ].sum()
-        exp_obs_logps += bern_sp.logpmf(i_val).sum()
+        exp_obs_logps = np.stack([norm_sp.logpdf(x_val), gamma_sp.logpdf(y_val)])[i_val]
+        exp_obs_logps += bern_sp.logpmf(i_val)
 
         m_val = np.stack([x_val, y_val])[i_val]
         logp_vals = M_logp_fn(p_val, m_val, i_val)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -176,7 +176,7 @@ def test_transformed_logprob(at_dist, dist_params, sp_dist, size):
         b_dist = sp.stats.norm(a_val, 1.0)
         b_val = b_dist.rvs(random_state=test_val_rng).astype(b_value_var.dtype)
 
-        exp_logprob_val = a_dist.logpdf(a_val).sum()
+        exp_logprob_val = a_dist.logpdf(a_val)
 
         a_trans_value = a_forward_fn(a_val)
         if a_val.ndim > 0:
@@ -187,7 +187,7 @@ def test_transformed_logprob(at_dist, dist_params, sp_dist, size):
                 sp.misc.derivative(a_backward_fn, a_trans_value, dx=1e-6)
             )
 
-        exp_logprob_val += np.log(np.linalg.det(jacobian_val)).sum()
+        exp_logprob_val += np.log(np.linalg.det(jacobian_val))
         exp_logprob_val += b_dist.logpdf(b_val).sum()
 
         logprob_val = logp_vals_fn(a_trans_value, b_val)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -149,9 +149,7 @@ def test_transformed_logprob(at_dist, dist_params, sp_dist, size):
     b_value_var.name = "b_value"
 
     transform_opt = TransformValuesOpt({a_value_var: DEFAULT_TRANSFORM})
-    res = joint_logprob(
-        b, {a: a_value_var, b: b_value_var}, extra_rewrites=transform_opt
-    )
+    res = joint_logprob({a: a_value_var, b: b_value_var}, extra_rewrites=transform_opt)
 
     test_val_rng = np.random.RandomState(3238)
 
@@ -200,7 +198,7 @@ def test_simple_transformed_logprob():
     x = x_rv.clone()
 
     transform_opt = TransformValuesOpt({x: DEFAULT_TRANSFORM})
-    tr_logp = joint_logprob(x_rv, {x_rv: x}, extra_rewrites=transform_opt)
+    tr_logp = joint_logprob({x_rv: x}, extra_rewrites=transform_opt)
 
     assert np.isclose(
         tr_logp.eval({x: np.log(2.5)}),
@@ -254,7 +252,6 @@ def test_hierarchical_uniform_transform():
         }
     )
     logp = joint_logprob(
-        x_rv,
         {lower_rv: lower, upper_rv: upper, x_rv: x},
         extra_rewrites=transform_opt,
     )
@@ -281,7 +278,6 @@ def test_nondefault_transforms():
     )
 
     logp = joint_logprob(
-        x_rv,
         {loc_rv: loc, scale_rv: scale, x_rv: x},
         extra_rewrites=transform_opt,
     )
@@ -319,7 +315,6 @@ def test_default_transform_multiout():
     transform_opt = TransformValuesOpt({x: DEFAULT_TRANSFORM})
 
     logp = joint_logprob(
-        x_rv,
         {x_rv: x},
         extra_rewrites=transform_opt,
     )
@@ -341,7 +336,6 @@ def test_nonexistent_default_transform():
     transform_opt = TransformValuesOpt({x: DEFAULT_TRANSFORM})
 
     logp = joint_logprob(
-        x_rv,
         {x_rv: x},
         extra_rewrites=transform_opt,
     )


### PR DESCRIPTION
This is a simple proposal to simplify the core `joint_logprob` function by removing the `vars` variable. This was raised as a possibility in https://github.com/aesara-devs/aeppl/pull/47/files#r689290490

```python
x_rv = at.random.normal(name="x")
y_rv = at.random.normal(x_rv, name="y")

x_vv = x_rv.clone()
y_vv = y_rv.clone()
```

```python
# Before:
joint_logprob(y_rv, {y_rv: y_vv, x_rv, x_vv})
```
```python
# After:
joint_logprob({y_rv: y_vv, x_rv, x_vv})
```

The point of this PR is simple to accept / reject this idea. I personally don't like what has to be done for the example below to work.

**Note that I branched off from #47 and only the last commit is relevant**

***

Only one type of graph / tests that we have implemented seems to not work straightforwardly: 

```python
def test_joint_logprob_incsubtensor(indices, size):
    """Make sure we can compute a joint log-probability for ``Y[idx] = data`` where ``Y`` is univariate."""
 
    rng = np.random.RandomState(232)
    mu = np.power(10, np.arange(np.prod(size))).reshape(size)
    sigma = 0.001
    data = rng.normal(mu[indices], 1.0)
    y_val = rng.normal(mu, sigma, size=size)


    Y_rv = at.random.normal(mu, sigma, size=size)
    Y_rv.name = "Y"
    y_value_var = Y_rv.clone()
    y_value_var.name = "y"


    Y_sst = at.set_subtensor(Y_rv[indices], data)


    assert isinstance(
        Y_sst.owner.op, (IncSubtensor, AdvancedIncSubtensor, AdvancedIncSubtensor1)
    )


    Y_sst_logp = joint_logprob({Y_rv: y_value_var, Y_sst: None}, sum=False)
```

Requiring the `Y_sst: None` ugly hack.