### PR TITLE
Prevent value variables from being cloned in `joint_logprob`

### DIFF
--- a/aeppl/joint_logprob.py
+++ b/aeppl/joint_logprob.py
@@ -119,6 +119,11 @@ def factorized_joint_logprob(
     lifted_rv_values = rv_remapper.rv_values
     replacements = lifted_rv_values.copy()
 
+    # To avoid cloning value variables, we map them to themselves in the
+    # `replacements` `dict` (i.e. entries already existing in `replacments`
+    # aren't cloned)
+    replacements.update({v: v for v in rv_values.values()})
+
     # Walk the graph from its inputs to its outputs and construct the
     # log-probability
     q = deque(fgraph.toposort())

--- a/tests/test_joint_logprob.py
+++ b/tests/test_joint_logprob.py
@@ -225,14 +225,20 @@ def test_persist_inputs():
     """Make sure we don't unnecessarily clone variables."""
     x = at.scalar("x")
     beta_rv = at.random.normal(0, 1, name="beta")
-    y_rv = at.random.normal(beta_rv * x, 1, name="y")
+    Y_rv = at.random.normal(beta_rv * x, 1, name="y")
 
-    beta = beta_rv.type()
-    y = y_rv.type()
+    beta_vv = beta_rv.type()
+    y_vv = Y_rv.clone()
 
-    logp = joint_logprob({beta_rv: beta, y_rv: y})
+    logp = joint_logprob({beta_rv: beta_vv, Y_rv: y_vv})
 
     assert x in ancestors([logp])
+
+    # Make sure we don't clone value variables when they're graphs.
+    y_vv_2 = y_vv * 2
+    logp_2 = joint_logprob({beta_rv: beta_vv, Y_rv: y_vv_2})
+
+    assert y_vv_2 in ancestors([logp_2])
 
 
 def test_ignore_logprob():


### PR DESCRIPTION
This PR prevents value variables from being cloned in the output of `joint_logprob`.  The end result is that identity is preserved in the output even when a value variable is itself a graph, instead of an "atomic" element (e.g. a `Constant` or `Variable` with no owner).

Closes #62