### PR TITLE
Refactor `joint_logprob` optimizations and main loop

### DIFF
--- a/aeppl/abstract.py
+++ b/aeppl/abstract.py
@@ -1,6 +1,9 @@
 import abc
 from functools import singledispatch
+from typing import List
 
+from aesara.graph.basic import Apply, Variable
+from aesara.graph.op import Op
 from aesara.tensor.random.op import RandomVariable
 
 
@@ -11,12 +14,19 @@ class MeasurableVariable(abc.ABC):
 MeasurableVariable.register(RandomVariable)
 
 
-@singledispatch
-def get_measurable_outputs(op, node):
+def get_measurable_outputs(op: Op, node: Apply) -> List[Variable]:
     """Return only the outputs that are measurable."""
+    if isinstance(op, MeasurableVariable):
+        return _get_measurable_outputs(op, node)
+    else:
+        return []
+
+
+@singledispatch
+def _get_measurable_outputs(op, node):
     return node.outputs
 
 
-@get_measurable_outputs.register(RandomVariable)
-def randomvariable_outputs(op, node):
+@_get_measurable_outputs.register(RandomVariable)
+def _get_measurable_outputs_RandomVariable(op, node):
     return node.outputs[1:]

--- a/aeppl/mixture.py
+++ b/aeppl/mixture.py
@@ -88,17 +88,22 @@ def get_stack_mixture_vars(
             join_axis = int(get_constant_value(join_axis))
         except ValueError:
             # TODO: Support symbolic join axes
-            return None
+            raise NotImplementedError(
+                "Symbolic `Join` axes are not supported in mixtures"
+            )
 
         if join_axis != 0:
             # TODO: Support other join axes
-            return None
+            raise NotImplementedError("Only `Join` axis 0 is supported in mixtures")
 
     if not all(
         rv.owner and isinstance(rv.owner.op, RandomVariable) for rv in mixture_rvs
     ):
         # Currently, all mixture components must be `RandomVariable` outputs
         # TODO: Allow constants and make them Dirac-deltas
+        # raise NotImplementedError(
+        #     "All mixture components must be `RandomVariable` outputs"
+        # )
         return None
 
     return mixture_rvs

--- a/aeppl/opt.py
+++ b/aeppl/opt.py
@@ -163,10 +163,19 @@ def naive_bcast_rv_lift(fgraph, node):
 
 
 logprob_rewrites_db = SequenceDB()
-logprob_rewrites_db.register("canonicalize", optdb["canonicalize"], -10, "basic")
 rv_sinking_db = EquilibriumDB()
+logprob_rewrites_db.name = "logprob_rewrites_db"
+logprob_rewrites_db.register(
+    "pre-canonicalize", optdb.query("+canonicalize"), -10, "basic"
+)
+
+rv_sinking_db.name = "rv_sinking_db"
 rv_sinking_db.register("dimshuffle_lift", local_dimshuffle_rv_lift, -5, "basic")
 rv_sinking_db.register("subtensor_lift", local_subtensor_rv_lift, -5, "basic")
 rv_sinking_db.register("broadcast_to_lift", naive_bcast_rv_lift, -5, "basic")
 rv_sinking_db.register("incsubtensor_lift", incsubtensor_rv_replace, -5, "basic")
+
 logprob_rewrites_db.register("sinking", rv_sinking_db, -10, "basic")
+logprob_rewrites_db.register(
+    "post-canonicalize", optdb.query("+canonicalize"), 10, "basic"
+)

--- a/aeppl/opt.py
+++ b/aeppl/opt.py
@@ -163,12 +163,27 @@ def naive_bcast_rv_lift(fgraph, node):
 
 
 logprob_rewrites_db = SequenceDB()
-rv_sinking_db = EquilibriumDB()
 logprob_rewrites_db.name = "logprob_rewrites_db"
 logprob_rewrites_db.register(
     "pre-canonicalize", optdb.query("+canonicalize"), -10, "basic"
 )
 
+
+class RVSinkingDB(EquilibriumDB):
+    r"""This `EquilibriumDB` doesn't hide its exceptions.
+
+    By setting `failure_callback` to ``None`` in the `EquilibriumOptimizer`\s
+    that `EquilibriumDB` generates, we're able to directly emit the desired
+    exceptions from within the `LocalOptimization`\s themselves.
+    """
+
+    def query(self, *tags, **kwtags):
+        res = super().query(*tags, **kwtags)
+        res.failure_callback = None
+        return res
+
+
+rv_sinking_db = RVSinkingDB()
 rv_sinking_db.name = "rv_sinking_db"
 rv_sinking_db.register("dimshuffle_lift", local_dimshuffle_rv_lift, -5, "basic")
 rv_sinking_db.register("subtensor_lift", local_subtensor_rv_lift, -5, "basic")


### PR DESCRIPTION
This PR refactors the optimizations steps and main loop in `joint_logprob` so that erroneous random variable warnings are no longer emitted.