### PR TITLE
Add `use_jacobian` keyword option

### DIFF
--- a/aeppl/transforms.py
+++ b/aeppl/transforms.py
@@ -72,7 +72,7 @@ class TransformedRV(RandomVariable, metaclass=DistributionMeta):
 
 
 @_logprob.register(TransformedRV)
-def transformed_logprob(op, values, *inputs, name=None, use_jacobian=True, **kwargs):
+def transformed_logprob(op, values, *inputs, use_jacobian=True, **kwargs):
     """Compute the log-likelihood graph for a `TransformedRV`.
 
     We assume that the value variable was back-transformed to be on the natural
@@ -80,18 +80,11 @@ def transformed_logprob(op, values, *inputs, name=None, use_jacobian=True, **kwa
     """
     (value,) = values
 
-    logprob = _logprob(op.base_op, values, *inputs, name=name, **kwargs)
-
-    if name:
-        logprob.name = f"{name}_logprob"
+    logprob = _logprob(op.base_op, values, *inputs, **kwargs)
 
     if use_jacobian:
         original_forward_value = op.transform.forward(value, *inputs)
         jacobian = op.transform.log_jac_det(original_forward_value, *inputs)
-
-        if name:
-            jacobian.name = f"{name}_logprob_jac"
-
         logprob += jacobian
 
     return logprob

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -193,16 +193,19 @@ def test_transformed_logprob(at_dist, dist_params, sp_dist, size):
         np.testing.assert_almost_equal(exp_logprob_val, logprob_val, decimal=decimals)
 
 
-def test_simple_transformed_logprob():
+@pytest.mark.parametrize("use_jacobian", [True, False])
+def test_simple_transformed_logprob_nojac(use_jacobian):
     x_rv = at.random.halfnormal(0, 3, name="x_rv")
     x = x_rv.clone()
 
     transform_opt = TransformValuesOpt({x: DEFAULT_TRANSFORM})
-    tr_logp = joint_logprob({x_rv: x}, extra_rewrites=transform_opt)
+    tr_logp = joint_logprob(
+        {x_rv: x}, extra_rewrites=transform_opt, use_jacobian=use_jacobian
+    )
 
     assert np.isclose(
         tr_logp.eval({x: np.log(2.5)}),
-        sp.stats.halfnorm(0, 3).logpdf(2.5) + np.log(2.5),
+        sp.stats.halfnorm(0, 3).logpdf(2.5) + (np.log(2.5) if use_jacobian else 0.0),
     )
 
 


### PR DESCRIPTION
This PR adds a `use_jacobian` keyword option that allows control over whether or not the Jacobian is included in the log-probability graphs when `_logprob` is applied to `TransformedRV`s.