### PR TITLE
Extend transforms to all `MeasurableVariable`s

### DIFF
--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -17,6 +17,7 @@ from aeppl.transforms import (
     TransformValuesMapping,
     TransformValuesOpt,
     _default_transformed_rv,
+    transformed_variable,
 )
 from tests.utils import assert_no_rvs
 
@@ -485,7 +486,7 @@ def test_mixture_transform():
     # The untransformed graph should be the same as the transformed graph after
     # replacing the `Y_rv` value variable with a transformed version of itself
     logp_nt_fg = FunctionGraph(outputs=[logp_no_trans], clone=False)
-    y_trans = at.exp(y_vv)
+    y_trans = transformed_variable(at.exp(y_vv), y_vv)
     y_trans.name = "y_log"
     logp_nt_fg.replace(y_vv, y_trans)
     logp_nt = logp_nt_fg.outputs[0]

--- a/tests/test_truncation.py
+++ b/tests/test_truncation.py
@@ -173,7 +173,6 @@ def test_deterministic_clipping():
     )
 
 
-@pytest.mark.xfail(reason="Transform does not work with Elemwise ops, see #60")
 def test_censored_transform():
     x_rv = at.random.normal(0.5, 1)
     cens_x_rv = at.clip(x_rv, 0, x_rv)


### PR DESCRIPTION
This PR extends the transform machinery so that it can apply to all `MeasurableVariable`s.  

It does so by generalizing the output variable handling in `transform_values` and simplifying the dynamic transform class creation and design.

As well, a `TransformedVariable` class has been added so that Jacobian calculations will now have the original, un-transformed value at hand and no longer need to apply and then invert a transform.  This approach can be generalized so that all combinations of forward and backward transforms can be "canceled" automatically by a local rewrite.

Closes #60 and #86