### PR TITLE
Introduce `ValuedVariable`

### DIFF
--- a/aeppl/__init__.py
+++ b/aeppl/__init__.py
@@ -6,7 +6,7 @@ del get_versions
 
 from aeppl.logprob import logprob  # isort: split
 
-from aeppl.joint_logprob import conditional_logprob, joint_logprob
+from aeppl.joint_logprob import DensityNotFound, conditional_logprob, joint_logprob
 from aeppl.printing import latex_pprint, pprint
 
 # isort: off

--- a/aeppl/joint_logprob.py
+++ b/aeppl/joint_logprob.py
@@ -1,29 +1,31 @@
 import warnings
-from collections import deque
-from typing import Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
 import aesara.tensor as at
-from aesara import config
-from aesara.graph.basic import graph_inputs, io_toposort
-from aesara.graph.op import compute_test_value
+from aesara.graph.fg import FunctionGraph
 from aesara.graph.rewriting.basic import GraphRewriter, NodeRewriter
 from aesara.tensor.var import TensorVariable
 
-from aeppl.abstract import get_measurable_outputs
+from aeppl.abstract import ValuedVariable, get_measurable_outputs
 from aeppl.logprob import _logprob
 from aeppl.rewriting import construct_ir_fgraph
-from aeppl.utils import rvs_to_value_vars
+
+if TYPE_CHECKING:
+    from aesara.graph.basic import Apply, Variable
+
+
+class DensityNotFound(Exception):
+    """An exception raised when a density cannot be found."""
 
 
 def conditional_logprob(
     *random_variables: TensorVariable,
     realized: Dict[TensorVariable, TensorVariable] = {},
-    warn_missing_rvs: bool = True,
     ir_rewriter: Optional[GraphRewriter] = None,
     extra_rewrites: Optional[Union[GraphRewriter, NodeRewriter]] = None,
     **kwargs,
-) -> Tuple[Dict[TensorVariable, TensorVariable], List[TensorVariable]]:
-    r"""Create a map between random variables and the associated conditional log-densities.
+) -> Tuple[Dict[TensorVariable, TensorVariable], Tuple[TensorVariable, ...]]:
+    r"""Create a map between random variables and their conditional log-probabilities.
 
     Consider the following Aesara model:
 
@@ -98,12 +100,9 @@ def conditional_logprob(
         A ``dict`` that maps realized random variables to their realized
         values. These values used in the generated conditional
         log-density graphs.
-    warn_missing_rvs
-        When ``True``, issue a warning when a `RandomVariable` is found in
-        the graph and doesn't have a corresponding value variable specified in
-        `rv_values`.
     ir_rewriter
-        Rewriter that produces the intermediate representation of Measurable Variables.
+        Rewriter that produces the intermediate representation of measurable
+        variables.
     extra_rewrites
         Extra rewrites to be applied (e.g. reparameterizations, transforms,
         etc.)
@@ -117,9 +116,17 @@ def conditional_logprob(
     value_variables
         A ``list`` of the created valued variables in the same order as the
         order in which their corresponding random variables were passed as
-        arguments. Empty if ``random_variables`` is empty.
+        arguments. Empty if `random_variables` is empty.
 
     """
+
+    deprecated_option = kwargs.pop("warn_missing_rvs", None)
+
+    if deprecated_option:
+        warnings.warn(
+            "The `warn_missing_rvs` option is deprecated and has been removed.",
+            DeprecationWarning,
+        )
 
     # Create value variables by cloning the input measurable variables
     original_rv_values = {}
@@ -133,133 +140,99 @@ def conditional_logprob(
     # graphs. We can thus use them to recover the original random variables to index the
     # maps to the logprob graphs and value variables before returning them.
     rv_values = {**original_rv_values, **realized}
-    vv_to_original_rvs = {vv: rv for rv, vv in rv_values.items()}
 
-    fgraph, rv_values, _ = construct_ir_fgraph(rv_values, ir_rewriter=ir_rewriter)
+    fgraph, _, memo = construct_ir_fgraph(rv_values, ir_rewriter=ir_rewriter)
 
-    # The interface for transformations assumes that the value variables are in
-    # the transformed space. To get the correct `shape` and `dtype` for the
-    # value variables we return we need to apply the forward transformation to
-    # our RV copies, and return the type of the resulting variable as a value
-    # variable.
-    vv_remapper = {}
     if extra_rewrites is not None:
-        extra_rewrites.add_requirements(fgraph, {**original_rv_values, **realized})
+        extra_rewrites.add_requirements(fgraph, rv_values, memo)
         extra_rewrites.apply(fgraph)
-        vv_remapper = fgraph.values_to_untransformed
 
-    rv_remapper = fgraph.preserve_rv_mappings
+    # We assign log-densities on a per-node basis, and not per-output/variable.
+    realized_vars = set()
+    new_to_old_rvs = {}
+    nodes_to_vals: Dict["Apply", List[Tuple["Variable", "Variable"]]] = {}
 
-    # This is the updated random-to-value-vars map with the lifted/rewritten
-    # variables.  The rewrites are supposed to produce new
-    # `MeasurableVariable`s that are amenable to `_logprob`.
-    updated_rv_values = rv_remapper.rv_values
+    for bnd_var, (old_mvar, old_val) in zip(fgraph.outputs, rv_values.items()):
+        mnode = bnd_var.owner
+        assert mnode and isinstance(mnode.op, ValuedVariable)
 
-    # Some rewrites also transform the original value variables. This is the
-    # updated map from the new value variables to the original ones, which
-    # we want to use as the keys in the final dictionary output
-    original_values = rv_remapper.original_values
+        rv_var, val_var = mnode.inputs
+        rv_node = rv_var.owner
 
-    # When a `_logprob` has been produced for a `MeasurableVariable` node, all
-    # other references to it need to be replaced with its value-variable all
-    # throughout the `_logprob`-produced graphs.  The following `dict`
-    # cumulatively maintains remappings for all the variables/nodes that needed
-    # to be recreated after replacing `MeasurableVariable`s with their
-    # value-variables.  Since these replacements work in topological order, all
-    # the necessary value-variable replacements should be present for each
-    # node.
-    replacements = updated_rv_values.copy()
+        if rv_node is None:
+            raise DensityNotFound(f"Couldn't derive a log-probability for {rv_var}")
 
-    # To avoid cloning the value variables, we map them to themselves in the
-    # `replacements` `dict` (i.e. entries already existing in `replacements`
-    # aren't cloned)
-    replacements.update({v: v for v in rv_values.values()})
+        if old_mvar in realized:
+            realized_vars.add(rv_var)
 
-    # Walk the graph from its inputs to its outputs and construct the
-    # log-probability
-    q = deque(fgraph.toposort())
+        # Do this just in case a value variable was changed.  (Some transforms
+        # do this.)
+        new_val = memo[old_val]
 
+        nodes_to_vals.setdefault(rv_node, []).append((val_var, new_val))
+
+        new_to_old_rvs[rv_var] = old_mvar
+
+    value_vars: Tuple["Variable", ...] = ()
     logprob_vars = {}
-    value_variables = {}
 
-    while q:
-        node = q.popleft()
+    for rv_node, rv_val_pairs in nodes_to_vals.items():
 
-        outputs = get_measurable_outputs(node.op, node)
+        outputs = get_measurable_outputs(rv_node.op, rv_node)
+
         if not outputs:
-            continue
+            raise DensityNotFound(f"Couldn't derive a log-probability for {rv_node}")
 
-        if any(o not in updated_rv_values for o in outputs):
-            if warn_missing_rvs:
-                warnings.warn(
-                    "Found a random variable that is not assigned a value variable: "
-                    f"{node.outputs}"
-                )
-            continue
+        if len(outputs) < len(rv_val_pairs):
+            raise ValueError(
+                f"Too many values ({rv_val_pairs}) bound to node {rv_node}."
+            )
 
-        q_value_vars = [replacements[q_rv_var] for q_rv_var in outputs]
+        assert len(outputs) == len(rv_val_pairs)
 
-        if not q_value_vars:
-            continue
+        rv_vals, rv_base_vals = zip(*rv_val_pairs)
 
-        # Replace `RandomVariable`s in the inputs with value variables.
-        # Also, store the results in the `replacements` map for the nodes
-        # that follow.
-        remapped_vars, _ = rvs_to_value_vars(
-            q_value_vars + list(node.inputs),
-            initial_replacements=replacements,
-        )
-        q_value_vars = remapped_vars[: len(q_value_vars)]
-        q_rv_inputs = remapped_vars[len(q_value_vars) :]
-
-        q_logprob_vars = _logprob(
-            node.op,
-            q_value_vars,
-            *q_rv_inputs,
+        rv_logprobs = _logprob(
+            rv_node.op,
+            rv_vals,
+            *rv_node.inputs,
             **kwargs,
         )
 
-        if not isinstance(q_logprob_vars, (list, tuple)):
-            q_logprob_vars = [q_logprob_vars]
+        if not isinstance(rv_logprobs, (tuple, list)):
+            rv_logprobs = (rv_logprobs,)
 
-        for q_value_var, q_logprob_var in zip(q_value_vars, q_logprob_vars):
+        for lp_out, rv_out, rv_base_val in zip(rv_logprobs, outputs, rv_base_vals):
+            old_mvar = new_to_old_rvs[rv_out]
 
-            q_value_var = original_values[q_value_var]
-            q_rv = vv_to_original_rvs[q_value_var]
+            if old_mvar.name:
+                lp_out.name = f"{rv_out.name}_logprob"
 
-            if q_rv.name:
-                q_logprob_var.name = f"{q_rv.name}_logprob"
+            logprob_vars[old_mvar] = lp_out
 
-            if q_rv in logprob_vars:
-                raise ValueError(
-                    f"More than one logprob factor was assigned to the random variable {q_rv}"
-                )
+            if rv_out not in realized_vars:
+                value_vars += (rv_base_val,)
 
-            logprob_vars[q_rv] = q_logprob_var
+        # # Recompute test values for the changes introduced by the
+        # # replacements above.
+        # if config.compute_test_value != "off":
+        #     for node in io_toposort(graph_inputs([rv_logprobs]), outputs):
+        #         compute_test_value(node)
 
-            q_value_var = vv_remapper.get(q_value_var, q_value_var)
-            value_variables[q_rv] = q_value_var
+    # Replace `ValuedVariable`s with their values
+    rv_logprobs_fg = FunctionGraph(outputs=tuple(logprob_vars.values()), clone=False)
+    rv_logprobs_fg.replace_all(
+        tuple((valued_var, valued_var.owner.inputs[1]) for valued_var in fgraph.outputs)
+    )
 
-        # Recompute test values for the changes introduced by the
-        # replacements above.
-        if config.compute_test_value != "off":
-            for node in io_toposort(graph_inputs(q_logprob_vars), q_logprob_vars):
-                compute_test_value(node)
-
-    missing_value_terms = set(vv_to_original_rvs.values()) - set(logprob_vars.keys())
-    if missing_value_terms:
-        raise RuntimeError(
-            f"The logprob terms of the following random variables could not be derived: {missing_value_terms}"
-        )
-
-    return logprob_vars, [value_variables[rv] for rv in original_rv_values.keys()]
+    return logprob_vars, value_vars
 
 
 def joint_logprob(
     *random_variables: List[TensorVariable],
     realized: Dict[TensorVariable, TensorVariable] = {},
     **kwargs,
-) -> Optional[Tuple[TensorVariable, List[TensorVariable]]]:
+) -> Optional[Tuple[TensorVariable, Tuple[TensorVariable, ...]]]:
     r"""Build the graph of the joint log-density of an Aesara graph.
 
     Consider the following Aesara model:

--- a/aeppl/tensor.py
+++ b/aeppl/tensor.py
@@ -1,84 +1,19 @@
 from typing import List, Optional, Union
 
-import aesara
 from aesara import tensor as at
-from aesara.graph.op import compute_test_value
 from aesara.graph.rewriting.basic import node_rewriter
 from aesara.tensor.basic import Join, MakeVector
 from aesara.tensor.elemwise import DimShuffle
-from aesara.tensor.extra_ops import BroadcastTo
 from aesara.tensor.random.op import RandomVariable
-from aesara.tensor.random.rewriting import local_dimshuffle_rv_lift, local_rv_size_lift
+from aesara.tensor.random.rewriting import local_dimshuffle_rv_lift
 
-from aeppl.abstract import MeasurableVariable, assign_custom_measurable_outputs
+from aeppl.abstract import (
+    MeasurableVariable,
+    ValuedVariable,
+    assign_custom_measurable_outputs,
+)
 from aeppl.logprob import _logprob, logprob
-from aeppl.rewriting import PreserveRVMappings, measurable_ir_rewrites_db
-
-
-@node_rewriter([BroadcastTo])
-def naive_bcast_rv_lift(fgraph, node):
-    """Lift a ``BroadcastTo`` through a ``RandomVariable`` ``Op``.
-
-    XXX: This implementation simply broadcasts the ``RandomVariable``'s
-    parameters, which won't always work (e.g. multivariate distributions).
-
-    TODO: Instead, it should use ``RandomVariable.ndim_supp``--and the like--to
-    determine which dimensions of each parameter need to be broadcasted.
-    Also, this doesn't need to remove ``size`` to perform the lifting, like it
-    currently does.
-    """
-
-    if not (
-        isinstance(node.op, BroadcastTo)
-        and node.inputs[0].owner
-        and isinstance(node.inputs[0].owner.op, RandomVariable)
-    ):
-        return None  # pragma: no cover
-
-    bcast_shape = node.inputs[1:]
-
-    rv_var = node.inputs[0]
-    rv_node = rv_var.owner
-
-    if hasattr(fgraph, "dont_touch_vars") and rv_var in fgraph.dont_touch_vars:
-        return None  # pragma: no cover
-
-    # Do not replace RV if it is associated with a value variable
-    rv_map_feature: Optional[PreserveRVMappings] = getattr(
-        fgraph, "preserve_rv_mappings", None
-    )
-    if rv_map_feature is not None and rv_var in rv_map_feature.rv_values:
-        return None
-
-    if not bcast_shape:
-        # The `BroadcastTo` is broadcasting a scalar to a scalar (i.e. doing nothing)
-        assert rv_var.ndim == 0
-        return [rv_var]
-
-    size_lift_res = local_rv_size_lift.transform(fgraph, rv_node)
-    if size_lift_res is None:
-        lifted_node = rv_node
-    else:
-        _, lifted_rv = size_lift_res
-        lifted_node = lifted_rv.owner
-
-    rng, size, dtype, *dist_params = lifted_node.inputs
-
-    new_dist_params = [
-        at.broadcast_to(
-            param,
-            at.broadcast_shape(
-                tuple(param.shape), tuple(bcast_shape), arrays_are_shapes=True
-            ),
-        )
-        for param in dist_params
-    ]
-    bcasted_node = lifted_node.op.make_node(rng, size, dtype, *new_dist_params)
-
-    if aesara.config.compute_test_value != "off":
-        compute_test_value(bcasted_node)
-
-    return [bcasted_node.outputs[1]]
+from aeppl.rewriting import measurable_ir_rewrites_db
 
 
 class MeasurableMakeVector(MakeVector):
@@ -149,13 +84,6 @@ def find_measurable_stacks(
     if isinstance(node.op, (MeasurableMakeVector, MeasurableJoin)):
         return None  # pragma: no cover
 
-    rv_map_feature: Optional[PreserveRVMappings] = getattr(
-        fgraph, "preserve_rv_mappings", None
-    )
-
-    if rv_map_feature is None:
-        return None  # pragma: no cover
-
     stack_out = node.outputs[0]
 
     is_join = isinstance(node.op, Join)
@@ -168,7 +96,7 @@ def find_measurable_stacks(
     if not all(
         base_var.owner
         and isinstance(base_var.owner.op, MeasurableVariable)
-        and base_var not in rv_map_feature.rv_values
+        and not isinstance(base_var, ValuedVariable)
         for base_var in base_vars
     ):
         return None  # pragma: no cover
@@ -237,13 +165,6 @@ def find_measurable_dimshuffles(fgraph, node) -> Optional[List[MeasurableDimShuf
     if isinstance(node.op, MeasurableDimShuffle):
         return None  # pragma: no cover
 
-    rv_map_feature: Optional[PreserveRVMappings] = getattr(
-        fgraph, "preserve_rv_mappings", None
-    )
-
-    if rv_map_feature is None:
-        return None  # pragma: no cover
-
     base_var = node.inputs[0]
 
     # We can only apply this rewrite directly to `RandomVariable`s, as those are
@@ -257,7 +178,7 @@ def find_measurable_dimshuffles(fgraph, node) -> Optional[List[MeasurableDimShuf
     if not (
         base_var.owner
         and isinstance(base_var.owner.op, RandomVariable)
-        and base_var not in rv_map_feature.rv_values
+        and not isinstance(base_var, ValuedVariable)
     ):
         return None  # pragma: no cover
 
@@ -280,11 +201,6 @@ measurable_ir_rewrites_db.register(
 # We register this later than `dimshuffle_lift` so that it is only applied as a fallback
 measurable_ir_rewrites_db.register(
     "find_measurable_dimshuffles", find_measurable_dimshuffles, "basic", "tensor"
-)
-
-
-measurable_ir_rewrites_db.register(
-    "broadcast_to_lift", naive_bcast_rv_lift, "basic", "tensor"
 )
 
 

--- a/docs/source/api/transforms.rst
+++ b/docs/source/api/transforms.rst
@@ -2,12 +2,65 @@
 Transforms
 ==========
 
+------------
+Introduction
+------------
+
+Random variables in an Aesara model graph can be transformed by AePPL in multiple ways.
+
+One way is by *explicitly* constructing a transform using Aesara `Op`\s within a model graph:
+
+.. code::
+
+    A_rv = at.random.normal(0, 1.0, name="A")
+    Z_rv = at.exp(A_rv)
+    Z_rv.name = "Z"
+
+    logp, (z_vv,) = joint_logprob(Z_rv)
+
+
+The resulting log-density should reflect the "change-of-variables" implied by taking the exponential of
+a normal random variable:
+
+    >>> print(aesara.pprint(logp))
+    ((-0.9189385332046727 + (-0.5 * (log(Z_vv) ** 2))) + (-1.0 * log(Z_vv)))
+
+
+Transforms can also be applied *implicitly* through the use of `TransformValuesRewrite`:
+
+.. code::
+
+    A_rv = at.random.normal(0, 1.0, name="A")
+    B_rv = at.random.normal(A_rv, 1.0, name="B")
+
+    logp, (a_vv, b_vv,) = joint_logprob(
+        A_rv,
+        B_rv,
+        extra_rewrites=TransformValuesRewrite(
+            {A_rv: ExpTransform()}
+        ),
+    )
+
+
+This approach will apply the designated transforms to all occurrences of their
+associated variables and their values:
+
+    >>> print(aesara.pprint(logp))
+    sum([((-0.9189385332046727 + (-0.5 * (log(A_vv-trans) ** 2))) + (-1.0 * log(A_vv-trans))),
+         (-0.9189385332046727 + (-0.5 * ((B_vv - log(A_vv-trans)) ** 2)))], axis=None)
+
+
+------------------------
+`TransformValuesRewrite`
+------------------------
+
+.. autoclass:: aeppl.transforms.TransformValuesRewrite
 
 ---------------------
 Invertible transforms
 ---------------------
 
-AePPL currently supports the following (invertible) Aesara operators. This means that AePPL can compute the log-density of a random variable that is the result of one of the following transformations applied to another random variable:
+AePPL currently supports transforms using the following (invertible) Aesara operators. This means that AePPL can compute the log-probability of a random variable that is the result of one of the following transformations applied to another random variable:
 
 - `aesara.tensor.add`
 - `aesara.tensor.sub`
@@ -33,6 +86,7 @@ These transformations can be chained using:
 
 
 .. autoclass:: aeppl.transforms.ChainedTransform
+
 
 ---------
 Censoring

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,7 +50,7 @@ add_function_parentheses = False
 
 # -- Options for extensions
 
-jupyter_execute_notebooks = "auto"
+nb_execution_mode = "auto"
 # execution_excludepatterns = ["*.ipynb"]
 myst_enable_extensions = ["colon_fence", "deflist", "dollarmath", "amsmath"]
 

--- a/tests/test_composite_logprob.py
+++ b/tests/test_composite_logprob.py
@@ -84,9 +84,9 @@ def test_unvalued_ir_reversion():
 
     z_fgraph, _, memo = construct_ir_fgraph(rv_values)
 
-    assert memo[y_rv] in z_fgraph.preserve_rv_mappings.measurable_conversions
+    assert memo[y_rv] in z_fgraph.measurable_conversions
 
-    measurable_y_rv = z_fgraph.preserve_rv_mappings.measurable_conversions[memo[y_rv]]
+    measurable_y_rv = z_fgraph.measurable_conversions[memo[y_rv]]
     assert isinstance(measurable_y_rv.owner.op, MeasurableClip)
 
     # `construct_ir_fgraph` should've reverted the un-valued measurable IR

--- a/tests/test_cumsum.py
+++ b/tests/test_cumsum.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 import scipy.stats as st
 
-from aeppl import joint_logprob
+from aeppl.joint_logprob import DensityNotFound, joint_logprob
 from tests.utils import assert_no_rvs
 
 
@@ -57,7 +57,7 @@ def test_bernoulli_cumsum(size, axis):
 def test_destructive_cumsum_fails():
     """Test that a cumsum that mixes dimensions fails"""
     x_rv = at.random.normal(size=(2, 2, 2)).cumsum()
-    with pytest.raises(UserWarning, match="Found a random variable that is not"):
+    with pytest.raises(DensityNotFound):
         joint_logprob(x_rv)
 
 

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -336,7 +336,6 @@ def test_scan_joint_logprob(require_inner_rewrites):
 
 @pytest.mark.xfail(reason="see #148")
 @aesara.config.change_flags(compute_test_value="raise")
-@pytest.mark.xfail(reason="see #148")
 def test_initial_values():
     srng = at.random.RandomStream(seed=2320)
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -676,15 +676,15 @@ def test_discrete_rv_multinary_transform_fails():
         joint_logprob(y_rv)
 
 
-@pytest.mark.xfail(reason="Check not implemented yet, see #51")
 def test_invalid_broadcasted_transform_rv_fails():
     loc = at.vector("loc")
     y_rv = loc + at.random.normal(0, 1, size=2, name="base_rv")
     y_rv.name = "y"
 
     logp, (y_vv,) = joint_logprob(y_rv)
-    logp.eval({y_vv: [0, 0, 0, 0], loc: [0, 0, 0, 0]})
-    assert False, "Should have failed before"
+
+    with pytest.raises(TypeError):
+        logp.eval({y_vv: [0, 0, 0, 0], loc: [0, 0, 0, 0]})
 
 
 @pytest.mark.parametrize("a", (1.0, 2.0))


### PR DESCRIPTION
This PR replaces #71 and addresses the issues and discussions therein.

The `ValuedVariable` `Op` adds the value variable to the graph so that `PreserveRVMappings` is no longer needed.  It also clarifies the definition and actions of rewrites that truly apply to a `MeasurableVariable` and its value variable simultaneously by making `ValuedVariable`s the targets and outputs of such rewrites.

For instance, the old `naive_bcast_rv_lift` can be refactored into a rewrite that takes and produces `ValuedVariable`s, and the `MeasurableVariable`/`RandomVariable` terms being broadcasted within the `ValuedVariable` can be lifted *and* have their corresponding scalar value variables broadcasted all in the same place and way.  This approach clarifies the nature of the rewrite and makes the entire operation consistent with respect to the relation that it represents.

Our current approach (i.e. `naive_bcast_rv_lift`) is inconsistent as a stand-alone rewrite, because it doesn't also handle the value variable broadcasting.  Instead, that is handled much further down the line within `_logprob` implementations; however, that approach is fraught with potentially hard(er)-to-track issues.

- [x] Refactor user-specified transforms (i.e. `TransformValuesRewrite`)
    Our whole approach to this needs to be rewritten, mostly because the current one is too convoluted.  We can simply have a helper function that performs a `FunctionGraph.replace_all` and adds Jacobian terms to the appropriate variables directly.
- [x] Finish refactoring `*Subtensor*` support
- [x] Finish refactoring `Scan` support
- [ ] Change use of the term "valued" to "bound"
- [x] Determine how we want to handle `test_persist_inputs`, `test_warn_random_not_found`, `test_multiple_rvs_to_same_value_raises`, and `test_fail_multiple_clip_single_base`
