### PR TITLE
Move `assign_custom_measurable_outputs` to `aeppl.abstract`

### DIFF
--- a/aeppl/abstract.py
+++ b/aeppl/abstract.py
@@ -1,6 +1,7 @@
 import abc
+from copy import copy
 from functools import singledispatch
-from typing import List
+from typing import Callable, List
 
 from aesara.graph.basic import Apply, Variable
 from aesara.graph.op import Op
@@ -30,3 +31,54 @@ def _get_measurable_outputs(op, node):
 @_get_measurable_outputs.register(RandomVariable)
 def _get_measurable_outputs_RandomVariable(op, node):
     return node.outputs[1:]
+
+
+def noop_measurable_outputs_fn(*args, **kwargs):
+    return None
+
+
+def assign_custom_measurable_outputs(
+    node: Apply,
+    measurable_outputs_fn: Callable = noop_measurable_outputs_fn,
+    type_prefix: str = "Unmeasurable",
+) -> Apply:
+    """Assign a custom ``_get_measurable_outputs`` dispatch function to a measurable variable instance.
+
+    The node is cloned and a custom `Op` that's a copy of the original node's
+    `Op` is created.  That custom `Op` replaces the old `Op` in the cloned
+    node, and then a custom dispatch implementation is created for the clone
+    `Op` in `_get_measurable_outputs`.
+
+    If `measurable_outputs_fn` isn't specified, a no-op is used; the result is
+    a clone of `node` that will effectively be ignored by
+    `factorized_joint_logprob`.
+
+    Parameters
+    ==========
+    node
+        The node to recreate with a new cloned `Op`.
+    measurable_outputs_fn
+        The function that will be assigned to the new cloned `Op` in the
+        `_get_measurable_outputs` dispatcher.
+        The default is a no-op function (i.e. no measurable outputs)
+    type_prefix
+        The prefix used for the new type's name.
+        The default is ``"Unmeasurable"``, which matches the default
+        ``"measurable_outputs_fn"``.
+    """
+
+    new_node = node.clone()
+    op_type = type(new_node.op)
+    new_op_type = type(
+        f"{type_prefix}{op_type.__name__}", (op_type,), op_type.__dict__.copy()
+    )
+
+    new_node.op = copy(new_node.op)
+    new_node.op.__class__ = new_op_type
+
+    # TODO: The above could be a stand-alone utility function for all sorts of
+    # instance-based dispatching
+
+    _get_measurable_outputs.register(new_op_type)(measurable_outputs_fn)
+
+    return new_node

--- a/aeppl/mixture.py
+++ b/aeppl/mixture.py
@@ -1,5 +1,4 @@
-from copy import copy
-from typing import Callable, List, Optional
+from typing import List, Optional
 
 import aesara.tensor as at
 import numpy as np
@@ -14,7 +13,7 @@ from aesara.tensor.random.opt import local_dimshuffle_rv_lift, local_subtensor_r
 from aesara.tensor.shape import shape_tuple
 from aesara.tensor.var import TensorVariable
 
-from aeppl.abstract import MeasurableVariable, _get_measurable_outputs
+from aeppl.abstract import MeasurableVariable, assign_custom_measurable_outputs
 from aeppl.logprob import _logprob, logprob
 from aeppl.opt import naive_bcast_rv_lift, rv_sinking_db, subtensor_ops
 from aeppl.utils import get_constant_value, indices_from_subtensor
@@ -162,53 +161,6 @@ def mixture_replace(fgraph, node):
     rv_map_feature.update_rv_maps(out_var, mixture_value_var, new_mixture_rv)
 
     return [new_mixture_rv]
-
-
-def noop_measurable_outputs_fn(*args, **kwargs):
-    return None
-
-
-def assign_custom_measurable_outputs(
-    node: Apply,
-    measurable_outputs_fn: Callable = noop_measurable_outputs_fn,
-    type_prefix: str = "Unmeasurable",
-) -> Apply:
-    """Assign a custom ``_get_measurable_outputs`` dispatch function to a measurable variable instance.
-
-    The node is cloned and a custom `Op` that's a copy of the original node's
-    `Op` is created.  That custom `Op` replaces the old `Op` in the cloned
-    node, and then a custom dispatch implementation is created for the clone
-    `Op` in `_get_measurable_outputs`.
-
-    Parameters
-    ==========
-    node
-        The node to recreate with a new cloned `Op`.
-    measurable_outputs_fn
-        The function that will be assigned to the new cloned `Op` in the
-        `_get_measurable_outputs` dispatcher.
-        The default is a no-op function (i.e. no measurable outputs)
-    type_prefix
-        The prefix used for the new type's name.
-        The default is "Unmeasurable", which matches the default
-        "measurable_outputs_fn".
-    """
-
-    new_node = node.clone()
-    op_type = type(new_node.op)
-    new_op_type = type(
-        f"{type_prefix}{op_type.__name__}", (op_type,), op_type.__dict__.copy()
-    )
-
-    new_node.op = copy(new_node.op)
-    new_node.op.__class__ = new_op_type
-
-    # TODO: The above could be a stand-alone utility function for all sorts of
-    # instance-based dispatching
-
-    _get_measurable_outputs.register(new_op_type)(measurable_outputs_fn)
-
-    return new_node
 
 
 @_logprob.register(MixtureRV)


### PR DESCRIPTION
This PR moves `assign_custom_measurable_outputs` to `aeppl.abstract` so that it can be used more generally.