### PR TITLE
Allow both edges of IntervalTransform to be None

### DIFF
--- a/aeppl/transforms.py
+++ b/aeppl/transforms.py
@@ -224,6 +224,8 @@ class IntervalTransform(RVTransform):
             return at.log(value - a)
         elif b is not None:
             return at.log(b - value)
+        else:
+            return value
 
     def backward(self, value, *inputs):
         a, b = self.args_fn(*inputs)
@@ -235,6 +237,8 @@ class IntervalTransform(RVTransform):
             return at.exp(value) + a
         elif b is not None:
             return b - at.exp(value)
+        else:
+            return value
 
     def log_jac_det(self, value, *inputs):
         a, b = self.args_fn(*inputs)
@@ -242,6 +246,8 @@ class IntervalTransform(RVTransform):
         if a is not None and b is not None:
             s = at.softplus(-value)
             return at.log(b - a) - 2 * s - value
+        elif a is None and b is None:
+            return 0
         else:
             return value
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -10,6 +10,7 @@ from numdifftools import Jacobian
 from aeppl.joint_logprob import factorized_joint_logprob, joint_logprob
 from aeppl.transforms import (
     DEFAULT_TRANSFORM,
+    IntervalTransform,
     LogOddsTransform,
     LogTransform,
     RVTransform,
@@ -442,3 +443,16 @@ def test_original_values_output_dict():
     logp_dict = factorized_joint_logprob({p_rv: p_vv}, extra_rewrites=tr)
 
     assert p_vv in logp_dict
+
+
+def test_useless_interval_transform():
+    x_rv = at.random.normal(0, 1)
+    x_vv = x_rv.clone()
+
+    transform_opt = TransformValuesOpt(
+        {x_vv: IntervalTransform(lambda *inputs: (None, None))}
+    )
+
+    logp = joint_logprob({x_rv: x_vv}, extra_rewrites=transform_opt)
+
+    assert np.isclose(logp.eval({x_vv: 5}), sp.stats.norm(0, 1).logpdf(5))


### PR DESCRIPTION
This situation cropped up in https://github.com/pymc-devs/pymc/pull/5087

In general, it seems useful to allow for the possibility of a useless IntervalTransform when working with truncated distributions