### PR TITLE
Nested logprob rewrites proof of concept

### DIFF
--- a/aeppl/mixture.py
+++ b/aeppl/mixture.py
@@ -260,8 +260,6 @@ def mixture_replace(fgraph, node):
 
     mixing_indices = node.inputs[1:]
 
-    mixture_value_var = rv_map_feature.rv_values[old_mixture_rv]
-
     # We loop through mixture components and collect all the array elements
     # that belong to each one (by way of their indices).
     mixture_rvs = []
@@ -299,8 +297,6 @@ def mixture_replace(fgraph, node):
 
     if old_mixture_rv.name:
         new_mixture_rv.name = f"{old_mixture_rv.name}-mixture"
-
-    rv_map_feature.update_rv_maps(old_mixture_rv, mixture_value_var, new_mixture_rv)
 
     return [new_mixture_rv]
 

--- a/aeppl/opt.py
+++ b/aeppl/opt.py
@@ -31,6 +31,9 @@ inc_subtensor_ops = (IncSubtensor, AdvancedIncSubtensor, AdvancedIncSubtensor1)
 subtensor_ops = (AdvancedSubtensor, AdvancedSubtensor1, Subtensor)
 
 
+UPSTREAM_VALUE = object()
+
+
 class PreserveRVMappings(Feature):
     r"""Keeps track of random variables and their respective value variables during
     graph rewrites in `rv_values`
@@ -63,6 +66,9 @@ class PreserveRVMappings(Feature):
             )
 
         fgraph.preserve_rv_mappings = self
+
+    def flag_upstream_value(self, var):
+        self.rv_values[var] = UPSTREAM_VALUE
 
     def update_rv_maps(
         self,
@@ -101,7 +107,7 @@ class PreserveRVMappings(Feature):
         variable associated with it and map it to the new node.
         """
         r_value_var = self.rv_values.pop(r, None)
-        if r_value_var is not None:
+        if r_value_var not in (None, UPSTREAM_VALUE):
             self.rv_values[new_r] = r_value_var
 
 

--- a/tests/test_composite_logprob.py
+++ b/tests/test_composite_logprob.py
@@ -1,0 +1,75 @@
+import aesara
+import aesara.tensor as at
+import numpy as np
+import scipy.stats as st
+
+from aeppl import joint_logprob
+
+
+def test_scalar_clipped_mixture():
+    x = at.clip(at.random.normal(loc=1), 0.5, 1.5)
+    x.name = "x"
+    y = at.random.beta(1, 2, name="y")
+
+    comps = at.stack(x, y)
+    comps.name = "comps"
+    idxs = at.random.bernoulli(0.4, name="idxs")
+    mix = comps[idxs]
+    mix.name = "mix"
+
+    mix_vv = mix.clone()
+    idxs_vv = idxs.clone()
+    logp = joint_logprob({idxs: idxs_vv, mix: mix_vv})
+
+    logp_fn = aesara.function([idxs_vv, mix_vv], logp)
+    assert logp_fn(0, 0.4) == -np.inf
+    assert np.isclose(logp_fn(0, 0.5), st.norm.logcdf(0.5, 1) + np.log(0.6))
+    assert np.isclose(logp_fn(0, 1.3), st.norm.logpdf(1.3, 1) + np.log(0.6))
+    assert np.isclose(logp_fn(1, 0.4), st.beta.logpdf(0.4, 1, 2) + np.log(0.4))
+
+
+def test_nested_scalar_mixtures():
+    x = at.random.normal(loc=-50, name="x")
+    y = at.random.normal(loc=50, name="y")
+    comps1 = at.stack(x, y)
+    comps1.name = "comps1"
+    idxs1 = at.random.bernoulli(0.5, name="idxs1")
+    mix1 = comps1[idxs1]
+    mix1.name = "mix1"
+
+    w = at.random.normal(loc=-100, name="w")
+    z = at.random.normal(loc=100, name="z")
+    comps2 = at.stack(w, z)
+    comps2.name = "comps2"
+    idxs2 = at.random.bernoulli(0.5, name="idxs2")
+    mix2 = comps2[idxs2]
+    mix2.name = "mix2"
+
+    comps12 = at.stack(mix1, mix2)
+    comps12.name = "comps12"
+    idxs12 = at.random.bernoulli(0.5, name="idxs12")
+    mix12 = comps12[idxs12]
+    mix12.name = "mix12"
+
+    idxs1_vv = idxs1.clone()
+    idxs2_vv = idxs2.clone()
+    idxs12_vv = idxs12.clone()
+    mix12_vv = mix12.clone()
+
+    logp = joint_logprob(
+        {idxs1: idxs1_vv, idxs2: idxs2_vv, idxs12: idxs12_vv, mix12: mix12_vv}
+    )
+    logp_fn = aesara.function([idxs1_vv, idxs2_vv, idxs12_vv, mix12_vv], logp)
+
+    expected_mu_logpdf = st.norm.logpdf(0) + np.log(0.5) * 3
+    assert np.isclose(logp_fn(0, 0, 0, -50), expected_mu_logpdf)
+    assert np.isclose(logp_fn(0, 1, 0, -50), expected_mu_logpdf)
+    assert np.isclose(logp_fn(1, 0, 0, 50), expected_mu_logpdf)
+    assert np.isclose(logp_fn(1, 1, 0, 50), expected_mu_logpdf)
+    assert np.isclose(logp_fn(0, 0, 1, -100), expected_mu_logpdf)
+    assert np.isclose(logp_fn(0, 1, 1, 100), expected_mu_logpdf)
+    assert np.isclose(logp_fn(1, 0, 1, -100), expected_mu_logpdf)
+    assert np.isclose(logp_fn(1, 1, 1, 100), expected_mu_logpdf)
+
+    assert np.isclose(logp_fn(0, 0, 0, 50), st.norm.logpdf(100) + np.log(0.5) * 3)
+    assert np.isclose(logp_fn(0, 0, 1, 50), st.norm.logpdf(150) + np.log(0.5) * 3)


### PR DESCRIPTION
This PR is a proof of concept for how we could handle composite RVs that require nested aeppl rewrites. The goal is to figure out if this approach is too limited / cumbersome and, if so, what could work better.

Roughly, most of our rewrites come in two parts:
1. Check if an initially non-measurable variable was assigned to a value variable
2. If so, try to convert this variable into an temporary measurable variable for which `_logprob` can be safely dispatched

In step 2, we often need inputs that are themselves measurable variables, but which don't have value variables assigned to them: 

https://github.com/aesara-devs/aeppl/blob/05d0c683aa568e59bab8fcce4618f89c57355122/aeppl/mixture.py#L283-L287

If these inputs are RandomVariables things are fine, as those are measurable by default. Otherwise, we might still be dealing with things that could be measurable... but we will never know because they don't (and shouldn't) have value variables and their corresponding rewrites won't be triggered due to step 1.

The illustrating example in this PR is a scalar mixture that has a clipped variable as one of it's components:

```python
    x = at.clip(at.random.normal(loc=1), 0.5, 1.5); x.name = "x"
    y = at.random.beta(1, 2, size=None, name="y")

    comps = at.stack(x, y); comps.name = "comps"
    idxs = at.random.bernoulli(0.4, size=None, name="idxs")
    mix = comps[idxs]; mix.name = "mix"

    mix_vv = mix.clone()
    idxs_vv = idxs.clone()
    logp = joint_logprob({idxs: idxs_vv, mix: mix_vv})
```

I have also added a test example with nested scalar mixtures

## Suggestion
The suggestion is that any rewrite that depends on other inputs being measurable, can assign a temporary value variable `UPSTREAM_VALUE` to those inputs. This value variable is automatically discarded by the `PreserveRVMappings` when such variables are converted to measurable ones by their own rewrites.

## Limitations
This would work for some current and future rewrites like #26, but not for everything. 

For example nested rewrites that depend on the direct manipulation / creation of value variables such as inc_subtensor and scans would not work. This would also not work when the `_logprob` dispatched function depends on having RandomVariables as inputs, as happens with non-scalar mixtures:

https://github.com/aesara-devs/aeppl/blob/05d0c683aa568e59bab8fcce4618f89c57355122/aeppl/mixture.py#L354

Also depending on the order with which rewrites are called this may not always work, because the attribution of the `UPSTREAM_VALUE` is not a visible graph change, and I guess the Equilibrium optimization will stop if after passing through all nodes, none is changed
