### PR TITLE
Remove unnecessary assert in `naive_bcast_rv_lift`

### DIFF
--- a/aeppl/opt.py
+++ b/aeppl/opt.py
@@ -178,13 +178,16 @@ def naive_bcast_rv_lift(fgraph, node):
 
     bcast_shape = node.inputs[1:]
 
-    assert len(bcast_shape) > 0
-
     rv_var = node.inputs[0]
     rv_node = rv_var.owner
 
     if hasattr(fgraph, "dont_touch_vars") and rv_var in fgraph.dont_touch_vars:
         return None  # pragma: no cover
+
+    if not bcast_shape:
+        # The `BroadcastTo` is broadcasting a scalar to a scalar (i.e. doing nothing)
+        assert rv_var.ndim == 0
+        return [rv_var]
 
     size_lift_res = local_rv_size_lift.transform(fgraph, rv_node)
     if size_lift_res is None:

--- a/tests/test_opt.py
+++ b/tests/test_opt.py
@@ -1,0 +1,18 @@
+import aesara.tensor as at
+from aesara.graph.opt import in2out
+from aesara.graph.opt_utils import optimize_graph
+from aesara.tensor.extra_ops import BroadcastTo
+
+from aeppl.opt import naive_bcast_rv_lift
+
+
+def test_naive_bcast_rv_lift():
+    r"""Make sure `test_naive_bcast_rv_lift` can handle useless scalar `BroadcastTo`\s."""
+    X_rv = at.random.normal()
+    Z_at = at.broadcast_to(X_rv, ())
+
+    # Make sure we're testing what we intend to test
+    assert isinstance(Z_at.owner.op, BroadcastTo)
+
+    res = optimize_graph(Z_at, custom_opt=in2out(naive_bcast_rv_lift), clone=False)
+    assert res is X_rv


### PR DESCRIPTION
This PR removes an overly restrictive `assert` in `naive_bcast_rv_lift`.  In doing so, it also simplifies unnecessary `BroadcastTo`s of scalars.