### PR TITLE
Remove Python 3.6 from the CI test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.6", "3.7"]
+        python-version: ["3.7", "3.10"]
         fast-compile: [0]
         float32: [0]
         part:


### PR DESCRIPTION
This PR updates the CI test matrix by removing Python 3.6, which is no longer supported, and adding 3.10.