### PR TITLE
Track value variables when lifting `BroadcastTo` `Op`s

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,10 +1,5 @@
-import sys
 import os
-import pathlib
 
-
-# import local version of library instead of installed one
-sys.path.insert(0, str(pathlib.Path(__file__).parent.resolve().parent.parent / "src"))
 import aeppl
 
 # -- Project information


### PR DESCRIPTION
This PR is an alternative to #116 that enables value-variable tracking for `BroadcastTo` lifting rewrites.  This approach allows one to specify values for broadcasted random variables that are also valued, whereas globally disabling the rewrite for valued terms would not.

The latter is most easily demonstrated by the following example:
``` python
import aesara.tensor as at

from aeppl import factorized_joint_logprob


X_rv = at.random.normal(name="X")
Z_rv = at.broadcast_to(X_rv, (2, 2))

x_vv = X_rv.clone()
z_vv = Z_rv.clone()

logp_map = factorized_joint_logprob({X_rv: x_vv, Z_rv: z_vv})
```

Closes #115


Also, this PR further demonstrates the relevance of #78, because it explicitly makes use of the fact that the lifting operation doesn't only apply to the valued variable, but also the variable's value.