### PR TITLE
Use the `HasInnerGraph` interface to get inner-inputs/outputs

### DIFF
--- a/aeppl/scan.py
+++ b/aeppl/scan.py
@@ -461,8 +461,8 @@ def add_opts_to_inner_graphs(fgraph, node):
         return None
 
     inner_fgraph = FunctionGraph(
-        node.op.inputs,
-        node.op.outputs,
+        node.op.inner_inputs,
+        node.op.inner_outputs,
         clone=True,
         copy_inputs=False,
         copy_orphans=False,
@@ -474,7 +474,7 @@ def add_opts_to_inner_graphs(fgraph, node):
 
     new_outputs = list(inner_fgraph.outputs)
 
-    op = Scan(node.op.inputs, new_outputs, node.op.info)
+    op = Scan(node.op.inner_inputs, new_outputs, node.op.info)
     new_node = op.make_node(*node.inputs)
 
     return dict(zip(node.outputs, new_node.outputs))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,5 @@
 from aesara.graph.basic import walk
-from aesara.scan.op import Scan
+from aesara.graph.op import HasInnerGraph
 
 from aeppl.abstract import MeasurableVariable
 
@@ -12,10 +12,8 @@ def assert_no_rvs(var):
         if owner:
             inputs = list(reversed(owner.inputs))
 
-            # TODO: We need a better--potentially type-based--means of
-            # determining whether or not an inner-graph is present
-            if isinstance(owner.op, Scan):
-                inputs += owner.op.outputs
+            if isinstance(owner.op, HasInnerGraph):
+                inputs += owner.op.inner_outputs
 
             return inputs
 


### PR DESCRIPTION
This PR generalizes AePPL's inner-graph interactions by using the `HasInnerGraph` interfaces where possible.  These updates will be necessary after https://github.com/aesara-devs/aesara/pull/824 is merged.