### PR TITLE
Perform log-probability rewrites on un-valued terms

### DIFF
--- a/aeppl/cumsum.py
+++ b/aeppl/cumsum.py
@@ -57,9 +57,6 @@ def find_measurable_cumsums(fgraph, node) -> Optional[List[MeasurableCumsum]]:
 
     rv = node.outputs[0]
 
-    if rv not in rv_map_feature.rv_values:
-        return None  # pragma: no cover
-
     base_rv = node.inputs[0]
     if not (
         base_rv.owner

--- a/aeppl/cumsum.py
+++ b/aeppl/cumsum.py
@@ -1,12 +1,12 @@
 from typing import List, Optional
 
 import aesara.tensor as at
-from aesara.graph.opt import local_optimizer, out2in
+from aesara.graph.opt import local_optimizer
 from aesara.tensor.extra_ops import CumOp
 
 from aeppl.abstract import MeasurableVariable, assign_custom_measurable_outputs
 from aeppl.logprob import _logprob, logprob
-from aeppl.opt import PreserveRVMappings, logprob_rewrites_db
+from aeppl.opt import PreserveRVMappings, measurable_ir_rewrites_db
 
 
 class MeasurableCumsum(CumOp):
@@ -81,11 +81,9 @@ def find_measurable_cumsums(fgraph, node) -> Optional[List[MeasurableCumsum]]:
     return [new_rv]
 
 
-logprob_rewrites_db.register(
+measurable_ir_rewrites_db.register(
     "find_measurable_cumsums",
-    out2in(
-        find_measurable_cumsums, name="find_measurable_cumsums", ignore_newtrees=True
-    ),
+    find_measurable_cumsums,
     0,
     "basic",
     "cumsum",

--- a/aeppl/mixture.py
+++ b/aeppl/mixture.py
@@ -5,7 +5,11 @@ import aesara.tensor as at
 from aesara.graph.basic import Apply, Variable
 from aesara.graph.fg import FunctionGraph
 from aesara.graph.op import Op, compute_test_value
-from aesara.graph.opt import local_optimizer, out2in, pre_greedy_local_optimizer
+from aesara.graph.opt import (
+    EquilibriumOptimizer,
+    local_optimizer,
+    pre_greedy_local_optimizer,
+)
 from aesara.ifelse import ifelse
 from aesara.tensor.basic import Join, MakeVector
 from aesara.tensor.random.opt import local_dimshuffle_rv_lift, local_subtensor_rv_lift
@@ -371,7 +375,9 @@ def logprob_MixtureRV(
 
 logprob_rewrites_db.register(
     "mixture_replace",
-    out2in(mixture_replace, name="mixture_replace", ignore_newtrees=True),
+    EquilibriumOptimizer(
+        [mixture_replace], max_use_ratio=aesara.config.optdb__max_use_ratio
+    ),
     0,
     "basic",
     "mixture",

--- a/aeppl/mixture.py
+++ b/aeppl/mixture.py
@@ -260,12 +260,9 @@ def mixture_replace(fgraph, node):
 
     old_mixture_rv = node.default_output()
 
-    if old_mixture_rv not in rv_map_feature.rv_values:
-        return None  # pragma: no cover
-
     mixture_res, join_axis = get_stack_mixture_vars(node)
 
-    if mixture_res is None:
+    if mixture_res is None or any(rv in rv_map_feature.rv_values for rv in mixture_res):
         return None  # pragma: no cover
 
     mixing_indices = node.inputs[1:]
@@ -274,10 +271,6 @@ def mixture_replace(fgraph, node):
     # that belong to each one (by way of their indices).
     mixture_rvs = []
     for i, component_rv in enumerate(mixture_res):
-        if component_rv in rv_map_feature.rv_values:
-            raise ValueError(
-                f"A value variable was specified for a mixture component: {component_rv}"
-            )
 
         # We create custom types for the mixture components and assign them
         # null `get_measurable_outputs` dispatches so that they aren't

--- a/aeppl/opt.py
+++ b/aeppl/opt.py
@@ -40,6 +40,20 @@ inc_subtensor_ops = (IncSubtensor, AdvancedIncSubtensor, AdvancedIncSubtensor1)
 subtensor_ops = (AdvancedSubtensor, AdvancedSubtensor1, Subtensor)
 
 
+class NoCallbackEquilibriumDB(EquilibriumDB):
+    r"""This `EquilibriumDB` doesn't hide its exceptions.
+
+    By setting `failure_callback` to ``None`` in the `EquilibriumOptimizer`\s
+    that `EquilibriumDB` generates, we're able to directly emit the desired
+    exceptions from within the `LocalOptimization`\s themselves.
+    """
+
+    def query(self, *tags, **kwtags):
+        res = super().query(*tags, **kwtags)
+        res.failure_callback = None
+        return res
+
+
 class PreserveRVMappings(Feature):
     r"""Keeps track of random variables and their respective value variables during
     graph rewrites in `rv_values`
@@ -269,29 +283,32 @@ logprob_rewrites_db.register(
     "pre-canonicalize", optdb.query("+canonicalize"), -10, "basic"
 )
 
+# These rewrites convert un-measurable variables into their measurable forms,
+# but they need to be reapplied, because some of the measurable forms require
+# their inputs to be measurable.
+measurable_ir_rewrites_db = NoCallbackEquilibriumDB()
+measurable_ir_rewrites_db.name = "measurable_ir_rewrites_db"
 
-class RVSinkingDB(EquilibriumDB):
-    r"""This `EquilibriumDB` doesn't hide its exceptions.
+logprob_rewrites_db.register(
+    "measurable_ir_rewrites", measurable_ir_rewrites_db, -10, "basic"
+)
 
-    By setting `failure_callback` to ``None`` in the `EquilibriumOptimizer`\s
-    that `EquilibriumDB` generates, we're able to directly emit the desired
-    exceptions from within the `LocalOptimization`\s themselves.
-    """
+# These rewrites push random/measurable variables "down", making them closer to
+# (or eventually) the graph outputs.  Often this is done by lifting other `Op`s
+# "up" through the random/measurable variables and into their inputs.
+measurable_ir_rewrites_db.register(
+    "dimshuffle_lift", local_dimshuffle_rv_lift, -5, "basic"
+)
+measurable_ir_rewrites_db.register(
+    "subtensor_lift", local_subtensor_rv_lift, -5, "basic"
+)
+measurable_ir_rewrites_db.register(
+    "broadcast_to_lift", naive_bcast_rv_lift, -5, "basic"
+)
+measurable_ir_rewrites_db.register(
+    "incsubtensor_lift", incsubtensor_rv_replace, -5, "basic"
+)
 
-    def query(self, *tags, **kwtags):
-        res = super().query(*tags, **kwtags)
-        res.failure_callback = None
-        return res
-
-
-rv_sinking_db = RVSinkingDB()
-rv_sinking_db.name = "rv_sinking_db"
-rv_sinking_db.register("dimshuffle_lift", local_dimshuffle_rv_lift, -5, "basic")
-rv_sinking_db.register("subtensor_lift", local_subtensor_rv_lift, -5, "basic")
-rv_sinking_db.register("broadcast_to_lift", naive_bcast_rv_lift, -5, "basic")
-rv_sinking_db.register("incsubtensor_lift", incsubtensor_rv_replace, -5, "basic")
-
-logprob_rewrites_db.register("sinking", rv_sinking_db, -10, "basic")
 logprob_rewrites_db.register(
     "post-canonicalize", optdb.query("+canonicalize"), 10, "basic"
 )

--- a/aeppl/opt.py
+++ b/aeppl/opt.py
@@ -1,13 +1,19 @@
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple
 
 import aesara
 import aesara.tensor as at
 from aesara.compile.mode import optdb
+from aesara.graph.basic import Variable
 from aesara.graph.features import Feature
+from aesara.graph.fg import FunctionGraph
 from aesara.graph.op import compute_test_value
 from aesara.graph.opt import local_optimizer
-from aesara.graph.optdb import EquilibriumDB, SequenceDB
-from aesara.tensor.basic_opt import register_canonicalize, register_useless
+from aesara.graph.optdb import EquilibriumDB, OptimizationQuery, SequenceDB
+from aesara.tensor.basic_opt import (
+    ShapeFeature,
+    register_canonicalize,
+    register_useless,
+)
 from aesara.tensor.elemwise import DimShuffle, Elemwise
 from aesara.tensor.extra_ops import BroadcastTo
 from aesara.tensor.random.op import RandomVariable
@@ -289,3 +295,74 @@ logprob_rewrites_db.register("sinking", rv_sinking_db, -10, "basic")
 logprob_rewrites_db.register(
     "post-canonicalize", optdb.query("+canonicalize"), 10, "basic"
 )
+
+
+def construct_ir_fgraph(
+    rv_values: Dict[Variable, Variable]
+) -> Tuple[FunctionGraph, Dict[Variable, Variable], Dict[Variable, Variable]]:
+    r"""Construct a `FunctionGraph` in measurable IR form for the keys in `rv_values`.
+
+    Our measurable IR takes the form of an Aesara graph that is more-or-less
+    equivalent to a given Aesara graph (i.e. the keys of `rv_values`) but
+    contains `Op`s that are subclasses of the `MeasurableVariable` type in
+    place of ones that do not inherit from `MeasurableVariable` in the original
+    graph but are nevertheless measurable.
+
+    `MeasurableVariable`\s are mapped to log-probabilities, so this IR is how
+    non-trivial log-probabilities are constructed, especially when the
+    "measurability" of a term depends on the measurability of its inputs
+    (e.g. a mixture).
+
+    In some cases, entire sub-graphs in the original graph are replaced with a
+    single measurable node.  In other cases, the relevant nodes are already
+    measurable and there is no difference between the resulting measurable IR
+    graph and the original.  In general, some changes will be present,
+    because--at the very least--canonicalization is always performed and the
+    measurable IR includes manipulations that are not applicable to outside of
+    the context of measurability/log-probabilities.
+
+    For instance, some `Op`s will be lifted through `MeasurableVariable`\s in
+    this IR, and the resulting graphs will not be computationally sound,
+    because they wouldn't produce independent samples when the original graph
+    would.  See https://github.com/aesara-devs/aeppl/pull/78.
+
+    Returns
+    -------
+    A `FunctionGraph` of the measurable IR, a copy of `rv_values` containing
+    the new, cloned versions of the original variables in `rv_values`, and
+    a ``dict`` mapping all the original variables to their cloned values in
+    `FunctionGraph`.
+    """
+
+    # Since we're going to clone the entire graph, we need to keep a map from
+    # the old nodes to the new ones; otherwise, we won't be able to use
+    # `rv_values`.
+    # We start the `dict` with mappings from the value variables to themselves,
+    # to prevent them from being cloned.
+    memo = {v: v for v in rv_values.values()}
+
+    # We add `ShapeFeature` because it will get rid of references to the old
+    # `RandomVariable`s that have been lifted; otherwise, it will be difficult
+    # to give good warnings when an unaccounted for `RandomVariable` is
+    # encountered
+    fgraph = FunctionGraph(
+        outputs=list(rv_values.keys()),
+        clone=True,
+        memo=memo,
+        copy_orphans=False,
+        copy_inputs=False,
+        features=[ShapeFeature()],
+    )
+
+    # Update `rv_values` so that it uses the new cloned variables
+    rv_values = {memo[k]: v for k, v in rv_values.items()}
+
+    # This `Feature` preserves the relationships between the original
+    # random variables (i.e. keys in `rv_values`) and the new ones
+    # produced when `Op`s are lifted through them.
+    rv_remapper = PreserveRVMappings(rv_values)
+    fgraph.attach_feature(rv_remapper)
+
+    logprob_rewrites_db.query(OptimizationQuery(include=["basic"])).optimize(fgraph)
+
+    return fgraph, rv_values, memo

--- a/aeppl/truncation.py
+++ b/aeppl/truncation.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import List, Optional
 
 import aesara.tensor as at
@@ -38,19 +37,13 @@ def find_censored_rvs(fgraph: FunctionGraph, node: Node) -> Optional[List[Censor
         return None
 
     clipped_var = node.outputs[0]
-    if clipped_var not in rv_map_feature.rv_values:
-        return None
-
     base_var, lower_bound, upper_bound = node.inputs
 
-    if not (base_var.owner and isinstance(base_var.owner.op, MeasurableVariable)):
-        return None
-
-    if base_var in rv_map_feature.rv_values:
-        warnings.warn(
-            f"Value variables were assigned to both the input ({base_var}) and "
-            f"output ({clipped_var}) of a censored random variable."
-        )
+    if not (
+        base_var.owner
+        and isinstance(base_var.owner.op, MeasurableVariable)
+        and base_var not in rv_map_feature.rv_values
+    ):
         return None
 
     # Replace bounds by `+-inf` if `y = clip(x, x, ?)` or `y=clip(x, ?, x)`

--- a/aeppl/truncation.py
+++ b/aeppl/truncation.py
@@ -5,7 +5,7 @@ import aesara.tensor as at
 import numpy as np
 from aesara.graph.basic import Node
 from aesara.graph.fg import FunctionGraph
-from aesara.graph.opt import local_optimizer, out2in
+from aesara.graph.opt import local_optimizer
 from aesara.scalar.basic import Clip
 from aesara.scalar.basic import clip as scalar_clip
 from aesara.tensor.elemwise import Elemwise
@@ -13,7 +13,7 @@ from aesara.tensor.var import TensorConstant
 
 from aeppl.abstract import MeasurableVariable, assign_custom_measurable_outputs
 from aeppl.logprob import CheckParameterValue, _logcdf, _logprob
-from aeppl.opt import logprob_rewrites_db
+from aeppl.opt import measurable_ir_rewrites_db
 
 
 class CensoredRV(Elemwise):
@@ -72,9 +72,9 @@ def find_censored_rvs(fgraph: FunctionGraph, node: Node) -> Optional[List[Censor
     return [censored_rv]
 
 
-logprob_rewrites_db.register(
+measurable_ir_rewrites_db.register(
     "find_censored_rvs",
-    out2in(find_censored_rvs, name="find_censored_rvs", ignore_newtrees=True),
+    find_censored_rvs,
     0,
     "basic",
     "censoring",

--- a/tests/test_composite_logprob.py
+++ b/tests/test_composite_logprob.py
@@ -1,0 +1,103 @@
+import aesara
+import aesara.tensor as at
+import numpy as np
+import scipy.stats as st
+
+from aeppl import joint_logprob
+from aeppl.opt import construct_ir_fgraph
+from aeppl.truncation import CensoredRV
+
+
+def test_scalar_clipped_mixture():
+    x = at.clip(at.random.normal(loc=1), 0.5, 1.5)
+    x.name = "x"
+    y = at.random.beta(1, 2, name="y")
+
+    comps = at.stack(x, y)
+    comps.name = "comps"
+    idxs = at.random.bernoulli(0.4, name="idxs")
+    mix = comps[idxs]
+    mix.name = "mix"
+
+    mix_vv = mix.clone()
+    mix_vv.name = "mix_val"
+    idxs_vv = idxs.clone()
+    idxs_vv.name = "idxs_val"
+
+    logp = joint_logprob({idxs: idxs_vv, mix: mix_vv})
+
+    logp_fn = aesara.function([idxs_vv, mix_vv], logp)
+    assert logp_fn(0, 0.4) == -np.inf
+    assert np.isclose(logp_fn(0, 0.5), st.norm.logcdf(0.5, 1) + np.log(0.6))
+    assert np.isclose(logp_fn(0, 1.3), st.norm.logpdf(1.3, 1) + np.log(0.6))
+    assert np.isclose(logp_fn(1, 0.4), st.beta.logpdf(0.4, 1, 2) + np.log(0.4))
+
+
+def test_nested_scalar_mixtures():
+    x = at.random.normal(loc=-50, name="x")
+    y = at.random.normal(loc=50, name="y")
+    comps1 = at.stack(x, y)
+    comps1.name = "comps1"
+    idxs1 = at.random.bernoulli(0.5, name="idxs1")
+    mix1 = comps1[idxs1]
+    mix1.name = "mix1"
+
+    w = at.random.normal(loc=-100, name="w")
+    z = at.random.normal(loc=100, name="z")
+    comps2 = at.stack(w, z)
+    comps2.name = "comps2"
+    idxs2 = at.random.bernoulli(0.5, name="idxs2")
+    mix2 = comps2[idxs2]
+    mix2.name = "mix2"
+
+    comps12 = at.stack(mix1, mix2)
+    comps12.name = "comps12"
+    idxs12 = at.random.bernoulli(0.5, name="idxs12")
+    mix12 = comps12[idxs12]
+    mix12.name = "mix12"
+
+    idxs1_vv = idxs1.clone()
+    idxs2_vv = idxs2.clone()
+    idxs12_vv = idxs12.clone()
+    mix12_vv = mix12.clone()
+
+    logp = joint_logprob(
+        {idxs1: idxs1_vv, idxs2: idxs2_vv, idxs12: idxs12_vv, mix12: mix12_vv}
+    )
+    logp_fn = aesara.function([idxs1_vv, idxs2_vv, idxs12_vv, mix12_vv], logp)
+
+    expected_mu_logpdf = st.norm.logpdf(0) + np.log(0.5) * 3
+    assert np.isclose(logp_fn(0, 0, 0, -50), expected_mu_logpdf)
+    assert np.isclose(logp_fn(0, 1, 0, -50), expected_mu_logpdf)
+    assert np.isclose(logp_fn(1, 0, 0, 50), expected_mu_logpdf)
+    assert np.isclose(logp_fn(1, 1, 0, 50), expected_mu_logpdf)
+    assert np.isclose(logp_fn(0, 0, 1, -100), expected_mu_logpdf)
+    assert np.isclose(logp_fn(0, 1, 1, 100), expected_mu_logpdf)
+    assert np.isclose(logp_fn(1, 0, 1, -100), expected_mu_logpdf)
+    assert np.isclose(logp_fn(1, 1, 1, 100), expected_mu_logpdf)
+
+    assert np.isclose(logp_fn(0, 0, 0, 50), st.norm.logpdf(100) + np.log(0.5) * 3)
+    assert np.isclose(logp_fn(0, 0, 1, 50), st.norm.logpdf(150) + np.log(0.5) * 3)
+
+
+def test_unvalued_ir_reversion():
+    """Make sure that un-valued IR rewrites are reverted."""
+    x_rv = at.random.normal()
+    y_rv = at.clip(x_rv, 0, 1)
+    z_rv = at.random.normal(y_rv, 1, name="z")
+    z_vv = z_rv.clone()
+
+    # Only the `z_rv` is "valued", so `y_rv` doesn't need to be converted into
+    # measurable IR.
+    rv_values = {z_rv: z_vv}
+
+    z_fgraph, _, memo = construct_ir_fgraph(rv_values)
+
+    assert memo[y_rv] in z_fgraph.preserve_rv_mappings.measurable_conversions
+
+    measurable_y_rv = z_fgraph.preserve_rv_mappings.measurable_conversions[memo[y_rv]]
+    assert isinstance(measurable_y_rv.owner.op, CensoredRV)
+
+    # `construct_ir_fgraph` should've reverted the un-valued measurable IR
+    # change
+    assert measurable_y_rv not in z_fgraph

--- a/tests/test_mixture.py
+++ b/tests/test_mixture.py
@@ -39,18 +39,21 @@ def test_mixture_basics():
 
         return locals()
 
-    with pytest.raises(ValueError, match=".*value variable was specified.*"):
-        env = create_mix_model(None, 0)
-        X_rv = env["X_rv"]
-        I_rv = env["I_rv"]
-        i_vv = env["i_vv"]
-        M_rv = env["M_rv"]
-        m_vv = env["m_vv"]
+    # TODO: This should raise explicitly, see #90
+    # with pytest.raises(ValueError, match=".*value variable was specified.*"):
+    env = create_mix_model(None, 0)
+    X_rv = env["X_rv"]
+    I_rv = env["I_rv"]
+    i_vv = env["i_vv"]
+    M_rv = env["M_rv"]
+    m_vv = env["m_vv"]
 
-        x_vv = X_rv.clone()
-        x_vv.name = "x"
+    x_vv = X_rv.clone()
+    x_vv.name = "x"
 
-        joint_logprob({M_rv: m_vv, I_rv: i_vv, X_rv: x_vv})
+    assert set(
+        factorized_joint_logprob({M_rv: m_vv, I_rv: i_vv, X_rv: x_vv}).keys()
+    ) == {x_vv, i_vv}
 
     with pytest.raises(NotImplementedError):
         axis_at = at.lscalar("axis")

--- a/tests/test_truncation.py
+++ b/tests/test_truncation.py
@@ -1,7 +1,6 @@
 import aesara
 import aesara.tensor as at
 import numpy as np
-import pytest
 import scipy as sp
 import scipy.stats as st
 
@@ -137,8 +136,7 @@ def test_fail_base_and_censored_have_values():
 
     x_vv = x_rv.clone()
     cens_x_vv = cens_x_rv.clone()
-    with pytest.warns(UserWarning):
-        logp_terms = factorized_joint_logprob({cens_x_rv: cens_x_vv, x_rv: x_vv})
+    logp_terms = factorized_joint_logprob({cens_x_rv: cens_x_vv, x_rv: x_vv})
     assert cens_x_vv not in logp_terms
 
 


### PR DESCRIPTION
Alternative approach to #102, this time relying on permissive intermediate rewrites whenever the relevant inputs are measurable and not themselves valued.

I think this approach is reasonable, except for the case where we have RVs in the graph that are not meant to be measured (see new xfail test):

```python
import aesara.tensor as at
from aeppl import joint_logprob

x = at.random.normal()
x.tag.ignore_logprob = True

y = at.clip(x, 0, 1)

z_rv = at.random.normal(y, 1, name="z")
z_vv = z_rv.clone()

logp = joint_logprob({z_rv: z_vv})
```
```
/home/ricardo/Documents/Projects/aeppl/aeppl/joint_logprob.py:161: UserWarning: Found a random variable that was neither among the observations nor the conditioned variables: [Elemwise{clip}.0]
  warnings.warn(
```

That issue is related to #85