### PR TITLE
Add HMM-constructing helper functions and `Op`s

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: debug-statements
       - id: check-merge-conflict
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3

--- a/aeppl/dists.py
+++ b/aeppl/dists.py
@@ -1,8 +1,17 @@
 import warnings
+from copy import copy
+from typing import Sequence
 
+import aesara
 import aesara.tensor as at
-from aesara.graph.basic import Apply
+import numpy as np
+from aesara.compile.builders import OpFromGraph
+from aesara.graph.basic import Apply, Constant
 from aesara.graph.op import Op
+from aesara.tensor.basic import make_vector
+from aesara.tensor.random.basic import categorical
+from aesara.tensor.random.utils import broadcast_params, normalize_size_param
+from aesara.tensor.var import TensorVariable
 
 from aeppl.abstract import MeasurableVariable
 
@@ -40,3 +49,188 @@ class DiracDelta(Op):
 dirac_delta = DiracDelta()
 
 MeasurableVariable.register(DiracDelta)
+
+
+def non_constant(x):
+    x = at.as_tensor_variable(x)
+    if isinstance(x, Constant):
+        # XXX: This isn't good for `size` parameters, because it could result
+        # in `at.get_vector_length` exceptions.
+        res = x.type()
+        res.tag = copy(res.tag)
+        if aesara.config.compute_test_value != "off":
+            res.tag.test_value = x.data
+        res.name = x.name
+        return res
+    else:
+        return x
+
+
+def switching_process(
+    comp_rvs: Sequence[TensorVariable],
+    states: TensorVariable,
+):
+    """Construct a switching process over arbitrary univariate mixtures and a state sequence.
+
+    This simply constructs a graph of the following form:
+
+        at.stack(comp_rvs)[states, *idx]
+
+    where ``idx`` makes sure that `states` selects mixture components along all
+    the other axes.
+
+    Parameters
+    ----------
+    comp_rvs
+        A list containing `MeasurableVariable` objects for each mixture component.
+    states
+        The hidden state sequence.  It should have a number of states
+        equal to the size of `comp_dists`.
+
+    """
+
+    states = at.as_tensor(states, dtype=np.int64)
+    comp_rvs_bcast = at.broadcast_arrays(*[at.as_tensor(rv) for rv in comp_rvs])
+    M_rv = at.stack(comp_rvs_bcast)
+    indices = (states,) + tuple(at.arange(d) for d in tuple(M_rv.shape)[1:])
+    rv_var = M_rv[indices]
+    return rv_var
+
+
+class DiscreteMarkovChainFactory(OpFromGraph):
+    """An `Op` constructed from an Aesara graph that represents a discrete Markov chain.
+
+    This "composite" `Op` allows us to mark a sub-graph as measurable and
+    assign a `_logprob` dispatch implementation.
+
+    As far as broadcasting is concerned, this `Op` has the following
+    `RandomVariable`-like properties:
+
+        ndim_supp = 1
+        ndims_params = (3, 1)
+
+    TODO: It would be nice to express this as a `Blockwise` `Op`.
+    """
+
+
+MeasurableVariable.register(DiscreteMarkovChainFactory)
+
+
+def create_discrete_mc_op(rng, size, Gammas, gamma_0):
+    """Construct a `DiscreteMarkovChainFactory` `Op`.
+
+    This returns a `Scan` that performs the follow:
+
+        states[0] = categorical(gamma_0)
+        for t in range(1, N):
+            states[t] = categorical(Gammas[t, state[t-1]])
+
+    The Aesara graph representing the above is wrapped in an `OpFromGraph` so
+    that we can easily assign it a specific log-probability.
+
+    TODO: Eventually, AePPL should be capable of parsing more sophisticated
+    `Scan`s and producing nearly the same log-likelihoods, and the use of
+    `OpFromGraph` will no longer be necessary.
+
+    """
+
+    # Again, we need to preserve the length of this symbolic vector, so we do
+    # this.
+    size_param = make_vector(
+        *[non_constant(size[i]) for i in range(at.get_vector_length(size))]
+    )
+    size_param.name = "size"
+
+    # We make shallow copies so that unwanted ancestors don't appear in the
+    # graph.
+    Gammas_param = non_constant(Gammas).type()
+    Gammas_param.name = "Gammas_param"
+
+    gamma_0_param = non_constant(gamma_0).type()
+    gamma_0_param.name = "gamma_0_param"
+
+    bcast_Gammas_param, bcast_gamma_0_param = broadcast_params(
+        (Gammas_param, gamma_0_param), (3, 1)
+    )
+
+    # Sample state 0 in each state sequence
+    state_0 = categorical(
+        bcast_gamma_0_param,
+        size=tuple(size_param) + tuple(bcast_gamma_0_param.shape[:-1]),
+        # size=at.join(0, size_param, bcast_gamma_0_param.shape[:-1]),
+        rng=rng,
+    )
+
+    N = bcast_Gammas_param.shape[-3]
+    states_shape = tuple(state_0.shape) + (N,)
+
+    bcast_Gammas_param = at.broadcast_to(
+        bcast_Gammas_param, states_shape + tuple(bcast_Gammas_param.shape[-2:])
+    )
+
+    def loop_fn(n, state_nm1, Gammas_inner, rng):
+        gamma_t = Gammas_inner[..., n, :, :]
+        idx = tuple(at.ogrid[[slice(None, d) for d in tuple(state_0.shape)]]) + (
+            state_nm1.T,
+        )
+        gamma_t = gamma_t[idx]
+        state_n = categorical(gamma_t, rng=rng)
+        return state_n.T
+
+    res, _ = aesara.scan(
+        loop_fn,
+        outputs_info=[{"initial": state_0.T, "taps": [-1]}],
+        sequences=[at.arange(N)],
+        non_sequences=[bcast_Gammas_param, rng],
+        # strict=True,
+    )
+
+    return DiscreteMarkovChainFactory(
+        [size_param, Gammas_param, gamma_0_param],
+        [res.T],
+        inline=True,
+        on_unused_input="ignore",
+    )
+
+
+def discrete_markov_chain(
+    Gammas: TensorVariable, gamma_0: TensorVariable, size=None, rng=None, **kwargs
+):
+    """Construct a first-order discrete Markov chain distribution.
+
+    This characterizes vector random variables consisting of state indicator
+    values (i.e. ``0`` to ``M - 1``) that are driven by a discrete Markov chain.
+
+
+    Parameters
+    ----------
+    Gammas
+        An array of transition probability matrices.  `Gammas` takes the
+        shape ``... x N x M x M`` for a state sequence of length ``N`` having
+        ``M``-many distinct states.  Each row, ``r``, in a transition probability
+        matrix gives the probability of transitioning from state ``r`` to each
+        other state.
+    gamma_0
+        The initial state probabilities.  The last dimension should be length ``M``,
+        i.e. the number of distinct states.
+    """
+    gamma_0 = at.as_tensor_variable(gamma_0)
+
+    assert Gammas.ndim >= 3
+
+    Gammas = at.as_tensor_variable(Gammas)
+
+    size = normalize_size_param(size)
+
+    if rng is None:
+        rng = aesara.shared(np.random.RandomState(), borrow=True)
+
+    DiscreteMarkovChainOp = create_discrete_mc_op(rng, size, Gammas, gamma_0)
+    rv_var = DiscreteMarkovChainOp(size, Gammas, gamma_0)
+
+    testval = kwargs.pop("testval", None)
+
+    if testval is not None:
+        rv_var.tag.test_value = testval
+
+    return rv_var

--- a/aeppl/printing.py
+++ b/aeppl/printing.py
@@ -38,7 +38,6 @@ try:
     def latex_print_array(data):  # pragma: no cover
         return sympy_latex(SympyArray(data))
 
-
 except ImportError:  # pragma: no cover
 
     def latex_print_array(data):

--- a/tests/test_dist.py
+++ b/tests/test_dist.py
@@ -1,10 +1,40 @@
 import aesara
 import aesara.tensor as at
+import aesara.tensor.random as atr
 import numpy as np
 import pytest
+import scipy.stats as sp
 from aesara.compile.mode import get_default_mode
 
-from aeppl.dists import dirac_delta
+from aeppl import joint_logprob
+from aeppl.dists import dirac_delta, discrete_markov_chain, switching_process
+from aeppl.logprob import logprob
+from tests.utils import simulate_poiszero_hmm
+
+
+def poisson_zero_process(mu=None, states=None, srng=None, **kwargs):
+    """A Poisson-Dirac-delta (at zero) mixture process.
+
+    The first mixture component (at index 0) is the Dirac-delta at zero, and
+    the second mixture component is the Poisson random variable.
+
+    Parameters
+    ----------
+    mu: tensor
+        The Poisson rate(s)
+    states: tensor
+        A vector of integer 0-1 states that indicate which component of
+        the mixture is active at each point/time.
+    """
+    mu = at.as_tensor_variable(mu)
+    states = at.as_tensor_variable(states)
+
+    # NOTE: This creates distributions that are *not* part of a `Model`
+    return switching_process(
+        [dirac_delta(at.as_tensor(0, dtype=np.int64)), srng.poisson(mu)],
+        states,
+        **kwargs
+    )
 
 
 def test_dirac_delta():
@@ -13,3 +43,590 @@ def test_dirac_delta():
     )
     with pytest.warns(UserWarning, match=".*DiracDelta.*"):
         assert np.array_equal(fn(), 1)
+
+
+def test_simulate_poiszero_hmm():
+    poiszero_sim = simulate_poiszero_hmm(30, 5000, seed=230)
+
+    assert poiszero_sim.keys() == {"P_tt", "S_t", "p_1", "p_0", "Y_t", "pi_0", "S_0"}
+
+    y_test = poiszero_sim["Y_t"].squeeze()
+    nonzeros_idx = poiszero_sim["S_t"] > 0
+
+    assert np.all(y_test[nonzeros_idx] > 0)
+    assert np.all(y_test[~nonzeros_idx] == 0)
+
+
+def test_discrete_markov_chain_random():
+    # A single transition matrix and initial probabilities vector for each
+    # element in the state sequence
+    test_Gamma_base = np.array([[[1.0, 0.0], [0.0, 1.0]]])
+    test_Gamma = np.broadcast_to(test_Gamma_base, (10, 2, 2))
+    test_gamma_0 = np.r_[0.0, 1.0]
+
+    test_sample = discrete_markov_chain(test_Gamma, test_gamma_0).eval()
+    assert np.all(test_sample == 1)
+
+    test_sample = discrete_markov_chain(test_Gamma, 1.0 - test_gamma_0, size=10).eval()
+    assert np.all(test_sample == 0)
+
+    test_sample = discrete_markov_chain(test_Gamma, test_gamma_0, size=12).eval()
+    assert test_sample.shape == (12, 10)
+
+    test_sample = discrete_markov_chain(test_Gamma, test_gamma_0, size=2).eval()
+    assert np.array_equal(
+        test_sample, np.stack([np.ones(10), np.ones(10)], 0).astype(int)
+    )
+
+    # Now, the same set-up, but--this time--generate two state sequences
+    # samples
+    test_Gamma_base = np.array([[[0.8, 0.2], [0.2, 0.8]]])
+    test_Gamma = np.broadcast_to(test_Gamma_base, (10, 2, 2))
+    test_gamma_0 = np.r_[0.2, 0.8]
+    test_sample = discrete_markov_chain(test_Gamma, test_gamma_0, size=2).eval()
+    # TODO: Fix the seed, and make sure there's at least one 0 and 1?
+    assert test_sample.shape == (2, 10)
+
+    # Two transition matrices--for two distinct state sequences--and one vector
+    # of initial probs.
+    test_Gamma_base = np.stack(
+        [np.array([[[1.0, 0.0], [0.0, 1.0]]]), np.array([[[1.0, 0.0], [0.0, 1.0]]])]
+    )
+    test_Gamma = np.broadcast_to(test_Gamma_base, (2, 10, 2, 2))
+    test_gamma_0 = np.r_[0.0, 1.0]
+
+    test_dist = discrete_markov_chain(test_Gamma, test_gamma_0)
+    test_sample = test_dist.eval()
+    assert np.array_equal(
+        test_sample, np.stack([np.ones(10), np.ones(10)], 0).astype(int)
+    )
+    assert test_sample.shape == (2, 10)
+
+    # Now, the same set-up, but--this time--generate three state sequence
+    # samples
+    test_dist = discrete_markov_chain(test_Gamma, test_gamma_0, size=3)
+    test_sample = test_dist.eval()
+    assert np.array_equal(
+        test_sample,
+        np.tile(np.stack([np.ones(10), np.ones(10)], 0).astype(int), (3, 1, 1)),
+    )
+    assert test_sample.shape == (3, 2, 10)
+
+    # Two transition matrices and initial probs. for two distinct state
+    # sequences
+    test_Gamma_base = np.stack(
+        [np.array([[[1.0, 0.0], [0.0, 1.0]]]), np.array([[[1.0, 0.0], [0.0, 1.0]]])]
+    )
+    test_Gamma = np.broadcast_to(test_Gamma_base, (2, 10, 2, 2))
+    test_gamma_0 = np.stack([np.r_[0.0, 1.0], np.r_[1.0, 0.0]])
+    test_dist = discrete_markov_chain(test_Gamma, test_gamma_0)
+    test_sample = test_dist.eval()
+    assert np.array_equal(
+        test_sample, np.stack([np.ones(10), np.zeros(10)], 0).astype(int)
+    )
+    assert test_sample.shape == (2, 10)
+
+    # Now, the same set-up, but--this time--generate three state sequence
+    # samples
+    test_dist = discrete_markov_chain(test_Gamma, test_gamma_0, size=3)
+    test_sample = test_dist.eval()
+    assert np.array_equal(
+        test_sample,
+        np.tile(np.stack([np.ones(10), np.zeros(10)], 0).astype(int), (3, 1, 1)),
+    )
+    assert test_sample.shape == (3, 2, 10)
+
+    # "Time"-varying transition matrices with a single vector of initial
+    # probabilities
+    test_Gamma = np.stack(
+        [
+            np.array([[0.0, 1.0], [1.0, 0.0]]),
+            np.array([[0.0, 1.0], [1.0, 0.0]]),
+            np.array([[1.0, 0.0], [0.0, 1.0]]),
+        ],
+        axis=0,
+    )
+    test_gamma_0 = np.r_[1, 0]
+
+    test_dist = discrete_markov_chain(test_Gamma, test_gamma_0)
+    test_sample = test_dist.eval()
+    assert np.array_equal(test_sample, np.r_[1, 0, 0])
+
+    # Now, the same set-up, but--this time--generate three state sequence
+    # samples
+    test_dist = discrete_markov_chain(test_Gamma, test_gamma_0, size=3)
+    test_sample = test_dist.eval()
+    assert np.array_equal(test_sample, np.tile(np.r_[1, 0, 0].astype(int), (3, 1)))
+
+    # "Time"-varying transition matrices with two initial
+    # probabilities vectors
+    test_Gamma = np.stack(
+        [
+            np.array([[0.0, 1.0], [1.0, 0.0]]),
+            np.array([[0.0, 1.0], [1.0, 0.0]]),
+            np.array([[1.0, 0.0], [0.0, 1.0]]),
+        ],
+        axis=0,
+    )
+    test_gamma_0 = np.array([[1, 0], [0, 1]])
+
+    test_dist = discrete_markov_chain(test_Gamma, test_gamma_0)
+    test_sample = test_dist.eval()
+    assert np.array_equal(test_sample, np.array([[1, 0, 0], [0, 1, 1]]))
+
+    # Now, the same set-up, but--this time--generate three state sequence
+    # samples
+    test_dist = discrete_markov_chain(test_Gamma, test_gamma_0, size=3)
+    test_sample = test_dist.eval()
+    assert np.array_equal(
+        test_sample, np.tile(np.array([[1, 0, 0], [0, 1, 1]]).astype(int), (3, 1, 1))
+    )
+
+    # Two "Time"-varying transition matrices with two initial
+    # probabilities vectors
+    test_Gamma = np.stack(
+        [
+            [
+                np.array([[0.0, 1.0], [1.0, 0.0]]),
+                np.array([[0.0, 1.0], [1.0, 0.0]]),
+                np.array([[1.0, 0.0], [0.0, 1.0]]),
+            ],
+            [
+                np.array([[1.0, 0.0], [0.0, 1.0]]),
+                np.array([[1.0, 0.0], [0.0, 1.0]]),
+                np.array([[0.0, 1.0], [1.0, 0.0]]),
+            ],
+        ],
+        axis=0,
+    )
+    test_gamma_0 = np.array([[1, 0], [0, 1]])
+
+    test_dist = discrete_markov_chain(test_Gamma, test_gamma_0)
+    test_sample = test_dist.eval()
+    assert np.array_equal(test_sample, np.array([[1, 0, 0], [1, 1, 0]]))
+
+    # Now, the same set-up, but--this time--generate three state sequence
+    # samples
+    test_dist = discrete_markov_chain(test_Gamma, test_gamma_0, size=3)
+    test_sample = test_dist.eval()
+    assert np.array_equal(
+        test_sample, np.tile(np.array([[1, 0, 0], [1, 1, 0]]).astype(int), (3, 1, 1))
+    )
+
+
+@pytest.mark.parametrize(
+    "Gammas, gamma_0, obs, exp_res",
+    [
+        pytest.param(
+            np.array([[[0.0, 1.0], [1.0, 0.0]]]),
+            np.r_[1.0, 0.0],
+            np.r_[1, 0, 1, 0],
+            # 0
+            None,
+            id=(
+                "A single transition matrix and initial probabilities vector for each "
+                "element in the state sequence"
+            ),
+        ),
+        pytest.param(
+            np.stack(
+                [
+                    np.array([[0.0, 1.0], [1.0, 0.0]]),
+                    np.array([[0.0, 1.0], [1.0, 0.0]]),
+                    np.array([[0.0, 1.0], [1.0, 0.0]]),
+                    np.array([[0.0, 1.0], [1.0, 0.0]]),
+                ],
+                axis=0,
+            ),
+            np.r_[1.0, 0.0],
+            np.r_[1, 0, 1, 0],
+            # 0,
+            None,
+            id='"Time"-varying transition matrices with a single vector of initial probabilities',
+        ),
+        pytest.param(
+            np.stack(
+                [
+                    np.array([[0.1, 0.9], [0.5, 0.5]]),
+                    np.array([[0.2, 0.8], [0.6, 0.4]]),
+                    np.array([[0.3, 0.7], [0.7, 0.3]]),
+                    np.array([[0.4, 0.6], [0.8, 0.2]]),
+                ],
+                axis=0,
+            ),
+            np.r_[0.3, 0.7],
+            np.r_[1, 0, 1, 0],
+            None,
+            id=(
+                '"Time"-varying transition matrices with a single vector of initial '
+                "probabilities, but--this time--with better test values"
+            ),
+        ),
+        pytest.param(
+            np.array([[[0.0, 1.0], [1.0, 0.0]]]),
+            np.r_[0.5, 0.5],
+            np.array([[1, 0, 1, 0], [0, 1, 0, 1]]),
+            # np.array([1, 1, 1, 1]),
+            None,
+            marks=pytest.mark.xfail(
+                reason=("Broadcasting for logp not supported"),
+                raises=NotImplementedError,
+            ),
+            id="Static transition matrix and two state sequences",
+        ),
+        pytest.param(
+            np.stack(
+                [
+                    np.array([[0.0, 1.0], [1.0, 0.0]]),
+                    np.array([[0.0, 1.0], [1.0, 0.0]]),
+                    np.array([[0.0, 1.0], [1.0, 0.0]]),
+                    np.array([[0.0, 1.0], [1.0, 0.0]]),
+                ],
+                axis=0,
+            ),
+            np.r_[0.5, 0.5],
+            np.array([[1, 0, 1, 0], [0, 1, 0, 1]]),
+            # np.array([1, 1, 1, 1]),
+            None,
+            marks=pytest.mark.xfail(
+                reason=("Broadcasting for logp not supported"),
+                raises=NotImplementedError,
+            ),
+            id="Time-varying transition matrices and two state sequences",
+        ),
+        pytest.param(
+            np.stack(
+                [
+                    [
+                        np.array([[0.0, 1.0], [1.0, 0.0]]),
+                        np.array([[0.0, 1.0], [1.0, 0.0]]),
+                        np.array([[0.0, 1.0], [1.0, 0.0]]),
+                        np.array([[0.0, 1.0], [1.0, 0.0]]),
+                    ],
+                    [
+                        np.array([[1.0, 0.0], [0.0, 1.0]]),
+                        np.array([[1.0, 0.0], [0.0, 1.0]]),
+                        np.array([[1.0, 0.0], [0.0, 1.0]]),
+                        np.array([[1.0, 0.0], [0.0, 1.0]]),
+                    ],
+                ],
+                axis=0,
+            ),
+            np.r_[0.5, 0.5],
+            np.array([[1, 0, 1, 0], [0, 0, 0, 0]]),
+            # np.array([1, 1, 1, 1]),
+            None,
+            marks=pytest.mark.xfail(
+                reason=("Broadcasting for logp not supported"),
+                raises=NotImplementedError,
+            ),
+            id="Two sets of time-varying transition matrices and two state sequences",
+        ),
+        pytest.param(
+            np.stack(
+                [
+                    [
+                        np.array([[0.0, 1.0], [1.0, 0.0]]),
+                        np.array([[0.0, 1.0], [1.0, 0.0]]),
+                        np.array([[0.0, 1.0], [1.0, 0.0]]),
+                        np.array([[0.0, 1.0], [1.0, 0.0]]),
+                    ],
+                    [
+                        np.array([[1.0, 0.0], [0.0, 1.0]]),
+                        np.array([[1.0, 0.0], [0.0, 1.0]]),
+                        np.array([[1.0, 0.0], [0.0, 1.0]]),
+                        np.array([[1.0, 0.0], [0.0, 1.0]]),
+                    ],
+                ],
+                axis=0,
+            ),
+            np.array([[0.5, 0.5], [0.5, 0.5]]),
+            np.array([[1, 0, 1, 0], [0, 0, 0, 0]]),
+            # np.array([1, 1, 1, 1]),
+            None,
+            marks=pytest.mark.xfail(
+                reason=("Broadcasting for logp not supported"),
+                raises=NotImplementedError,
+            ),
+            id=(
+                "Two sets of time-varying transition matrices--via `gamma_0` "
+                "broadcasting--and two state sequences"
+            ),
+        ),
+    ],
+)
+def test_discrete_Markov_chain_logp(Gammas, gamma_0, obs, exp_res):
+    test_dist = discrete_markov_chain(Gammas, gamma_0)
+    test_logp_at = logprob(test_dist, at.as_tensor(obs))
+    test_logp_val = test_logp_at.eval()
+
+    if exp_res is None:
+
+        def logp_single_chain(Gammas, gamma_0, obs):
+            state_transitions = np.stack([obs[:-1], obs[1:]]).T
+
+            p_S_0_to_1 = gamma_0.dot(Gammas[0])
+
+            p_S_obs = np.empty_like(obs, dtype=np.float64)
+            p_S_obs[0] = p_S_0_to_1[obs[0]]
+
+            for t, (S_tm1, S_t) in enumerate(state_transitions):
+                p_S_obs[t + 1] = Gammas[t, S_tm1, S_t]
+
+            return np.log(p_S_obs)
+
+        logp_fn = np.vectorize(logp_single_chain, signature="(n,m,m),(m),(n)->(n)")
+
+        Gammas = np.broadcast_to(Gammas, (obs.shape[0],) + Gammas.shape[-2:])
+        exp_res = logp_fn(Gammas, gamma_0, obs)
+
+    assert np.allclose(test_logp_val, exp_res)
+
+
+def test_switching_process_random():
+    test_states = np.r_[0, 0, 1, 1, 0, 1]
+    mu_zero_nonzero = [at.as_tensor(0), at.as_tensor(1)]
+    test_dist = switching_process(mu_zero_nonzero, test_states)
+    assert np.array_equal(test_dist.shape.eval(), test_states.shape)
+    test_sample = test_dist.eval()
+    assert test_sample.shape == (test_states.shape[0],)
+    assert np.all(test_sample[test_states > 0] > 0)
+
+    test_states_sized = np.broadcast_to(test_states, (5,) + test_states.shape)
+    test_sample = switching_process(mu_zero_nonzero, test_states_sized).eval()
+    assert np.array_equal(test_sample.shape, (5,) + test_states.shape)
+    assert np.all(test_sample[..., test_states > 0] > 0)
+
+    test_states = at.lvector("states")
+    test_states.tag.test_value = np.r_[0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0]
+    test_dist = switching_process(mu_zero_nonzero, test_states)
+    assert np.array_equal(
+        test_dist.shape.eval({test_states: test_states.tag.test_value}),
+        test_states.tag.test_value.shape,
+    )
+    test_states_sized = at.broadcast_to(test_states, (1,) + tuple(test_states.shape))
+    test_sample = switching_process(mu_zero_nonzero, test_states_sized).eval(
+        {test_states: test_states.tag.test_value}
+    )
+    assert np.array_equal(test_sample.shape, (1,) + test_states.tag.test_value.shape)
+    assert np.all(test_sample[..., test_states.tag.test_value > 0] > 0)
+
+    test_states = np.r_[0, 0, 1, 1, 0, 1]
+    test_mus = [at.as_tensor(i) for i in range(6)]
+    test_dist = switching_process(test_mus, test_states)
+    assert np.array_equal(test_dist.shape.eval(), test_states.shape)
+    test_sample = test_dist.eval()
+    assert np.array_equal(test_sample.shape, test_states.shape)
+    assert np.all(test_sample[..., test_states > 0] > 0)
+
+    test_states = np.c_[0, 0, 1, 1, 0, 1].T
+    test_mus = np.arange(1, 6).astype(np.float64)
+    # One of the states has emissions that are a sequence of five Dirac delta
+    # distributions on the values 1 to 5 (i.e. the one with values
+    # `test_mus`), and the other is just a single delta at 0.  A single state
+    # sample from this emissions mixture is a length five array of zeros or the
+    # values 1 to 5.
+    # Instead of specifying a state sequence containing only one state, we use
+    # six state sequences--each of length one.  This should give us six samples
+    # of either five zeros or the values 1 to 5.
+    test_dist = switching_process(
+        [at.as_tensor(0), at.as_tensor(test_mus)], test_states
+    )
+    assert np.array_equal(test_dist.shape.eval(), (6, 5))
+    test_sample = test_dist.eval()
+    assert np.array_equal(test_sample.shape, test_dist.shape.eval())
+    sample_mus = test_sample[np.where(test_states > 0)[0]]
+    assert np.all(sample_mus == test_mus)
+
+    test_states = np.c_[0, 0, 1, 1, 0, 1]
+    test_mus = np.arange(1, 7).astype(np.float64)
+    test_dist = switching_process(
+        [at.as_tensor(0), at.as_tensor(test_mus)], test_states
+    )
+    assert np.array_equal(test_dist.shape.eval(), test_states.shape)
+
+    test_states = np.r_[0, 0, 1, 1, 0, 1]
+    test_states_sized = np.broadcast_to(test_states, (3,) + test_states.shape)
+    test_sample = switching_process(
+        [at.as_tensor(0), at.as_tensor(test_mus)], test_states_sized
+    ).eval()
+    assert np.array_equal(test_sample.shape, (3,) + test_mus.shape)
+    assert np.all(test_sample.sum(0)[..., test_states > 0] > 0)
+
+    # Some misc. tests
+    rng = aesara.shared(np.random.RandomState(2023532), borrow=True)
+
+    test_states = np.r_[2, 0, 1, 2, 0, 1]
+    test_dists = [
+        at.as_tensor(0),
+        atr.poisson(100.0, rng=rng),
+        atr.poisson(1000.0, rng=rng),
+    ]
+    test_dist = switching_process(test_dists, test_states)
+    assert np.array_equal(test_dist.shape.eval(), test_states.shape)
+
+    test_sample = test_dist.eval()
+    assert test_sample.shape == (test_states.shape[0],)
+    assert np.all(test_sample[test_states == 0] == 0)
+    assert np.all(0 < test_sample[test_states == 1])
+    assert np.all(test_sample[test_states == 1] < 1000)
+    assert np.all(100 < test_sample[test_states == 2])
+
+    test_states = np.r_[2, 0, 1, 2, 0, 1]
+    test_mus = np.r_[100, 100, 500, 100, 100, 100]
+    test_dists = [
+        at.as_tensor(0),
+        atr.poisson(test_mus, rng=rng),
+        atr.poisson(10000.0, rng=rng),
+    ]
+    test_dist = switching_process(test_dists, test_states)
+    assert np.array_equal(test_dist.shape.eval(), test_states.shape)
+
+    test_sample = test_dist.eval()
+    assert test_sample.shape == (test_states.shape[0],)
+    assert np.all(200 < test_sample[2] < 600)
+    assert np.all(0 < test_sample[5] < 200)
+    assert np.all(5000 < test_sample[test_states == 2])
+
+    # Try a continuous mixture
+    test_states = np.r_[2, 0, 1, 2, 0, 1]
+    test_dists = [
+        atr.normal(0.0, 1.0, rng=rng),
+        atr.normal(100.0, 1.0, rng=rng),
+        atr.normal(1000.0, 1.0, rng=rng),
+    ]
+    test_dist = switching_process(test_dists, test_states)
+    assert np.array_equal(test_dist.shape.eval(), test_states.shape)
+
+    test_sample = test_dist.eval()
+    assert test_sample.shape == (test_states.shape[0],)
+    assert np.all(test_sample[test_states == 0] < 10)
+    assert np.all(50 < test_sample[test_states == 1])
+    assert np.all(test_sample[test_states == 1] < 150)
+    assert np.all(900 < test_sample[test_states == 2])
+
+    # Make sure we can use a large number of distributions in the mixture
+    test_states = np.ones(50, dtype=np.int64)
+    test_dists = [at.as_tensor(i) for i in range(50)]
+    test_dist = switching_process(test_dists, test_states)
+    assert np.array_equal(test_dist.shape.eval(), test_states.shape)
+
+    test_states = np.r_[2, 0, 1, 2, 0, 1]
+    test_dists = [atr.poisson(0.0), atr.poisson(100.0), atr.poisson(1000.0)]
+    test_dist = switching_process(test_dists, test_states)
+    assert np.array_equal(test_dist.shape.eval(), test_states.shape)
+
+    test_sample = test_dist.eval()
+    assert test_sample.shape == (test_states.shape[0],)
+    assert np.all(test_sample[test_states == 0] == 0)
+    assert np.all(0 < test_sample[test_states == 1])
+    assert np.all(test_sample[test_states == 1] < 1000)
+    assert np.all(100 < test_sample[test_states == 2])
+
+    test_mus = np.r_[100, 100, 500, 100, 100, 100]
+    test_dists = [
+        dirac_delta(at.as_tensor(0)),
+        atr.poisson(test_mus),
+        atr.poisson(10000.0),
+    ]
+    test_dist = switching_process(test_dists, test_states)
+    assert np.array_equal(test_dist.shape.eval(), test_states.shape)
+
+    test_sample = test_dist.eval()
+    assert test_sample.shape == (test_states.shape[0],)
+    assert np.all(200 < test_sample[2] < 600)
+    assert np.all(0 < test_sample[5] < 200)
+    assert np.all(5000 < test_sample[test_states == 2])
+
+
+def test_switching_process_logp():
+
+    srng = atr.RandomStream(2023532)
+
+    states_rv = srng.categorical([1 / 3, 1 / 3, 1 / 3], size=6, name="states")
+    states_vv = states_rv.clone()
+    states_vv.name = "states_vv"
+
+    states_vals = np.r_[2, 0, 1, 2, 0, 1]
+    states_vv.tag.test_value = states_vals
+
+    test_dists = [
+        dirac_delta(at.as_tensor(0, dtype=np.int64)),
+        srng.poisson(100),
+        srng.poisson(1000),
+    ]
+    test_dist = switching_process(test_dists, states_rv)
+    sw_vv = test_dist.clone()
+    sw_vv.name = "sw_vv"
+
+    test_logp = joint_logprob({test_dist: sw_vv, states_rv: states_vv}, sum=False)
+    obs_vals = np.array([1000, 0, 100, 1000, 0, 100], dtype=np.int64)
+    test_logp_val = test_logp.eval({sw_vv: obs_vals, states_vv: states_vals})
+
+    np.testing.assert_array_almost_equal(
+        test_logp_val[states_vals == 0], np.array([np.log(1 / 3)] * 2)
+    )
+    np.testing.assert_array_almost_equal(
+        test_logp_val[states_vals == 1],
+        np.array([np.log(1 / 3) + sp.poisson(100).logpmf(100)] * 2),
+        decimal=5,
+    )
+    np.testing.assert_array_almost_equal(
+        test_logp_val[states_vals == 2],
+        np.array([np.log(1 / 3) + sp.poisson(1000).logpmf(1000)] * 2),
+        decimal=4,
+    )
+
+    # Evaluate multiple observed state sequences in an extreme case
+    states_rv = srng.categorical([1 / 2, 1 / 2], size=(10, 4), name="states")
+    states_vv = states_rv.clone()
+    states_vv.name = "states_vv"
+
+    test_dist = switching_process(
+        [
+            dirac_delta(at.as_tensor(0, dtype=np.int64)),
+            dirac_delta(at.as_tensor(1, dtype=np.int64)),
+        ],
+        states_rv,
+    )
+    test_dist.name = "switching_dist"
+
+    test_obs = at.tile(np.arange(4), (10, 1)).astype(np.int64)
+
+    test_logp = joint_logprob({test_dist: test_obs, states_rv: states_vv}, sum=False)
+
+    exp_logp = np.tile(
+        np.array([np.log(0.5)] + [-np.inf] * 3, dtype=aesara.config.floatX), (10, 1)
+    )
+    test_logp_val = test_logp.eval({states_vv: np.zeros((10, 4)).astype(np.int64)})
+    assert np.array_equal(test_logp_val, exp_logp)
+
+
+def test_poisson_zero_process_model():
+    srng = atr.RandomStream(seed=2023532)
+
+    test_mean = at.repeat(at.as_tensor(1000.0), 20)
+    states = srng.bernoulli(0.5, size=20, name="states")
+
+    Y = poisson_zero_process(test_mean, states, srng=srng)
+
+    # We want to make sure that the sampled states and observations correspond,
+    # because, if there are any zero states with non-zero observations, we know
+    # that the sampled states weren't actually used to draw the observations,
+    # and that's a big problem
+    sample_fn = aesara.function([], [states, Y])
+
+    fgraph = sample_fn.maker.fgraph
+    nodes = list(fgraph.apply_nodes)
+    bernoulli_nodes = set(
+        n for n in nodes if isinstance(n.op, type(at.random.bernoulli))
+    )
+    assert len(bernoulli_nodes) == 1
+
+    for i in range(100):
+        test_states, test_Y = sample_fn()
+        assert np.all(0 < test_Y[..., test_states > 0])
+        assert np.all(test_Y[..., test_states > 0] < 10000)
+        # Make sure we're sampling different values each time
+        unique_nonzero_Y = set(y for y in test_Y if y > 0)
+        assert len(unique_nonzero_Y) > 1

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -40,14 +40,11 @@ class DirichletScipyDist:
         return samples
 
     def logpdf(self, value):
-        res = (
-            np.sum(
-                scipy.special.xlogy(self.alphas - 1, value)
-                - scipy.special.gammaln(self.alphas),
-                axis=-1,
-            )
-            + scipy.special.gammaln(np.sum(self.alphas, axis=-1))
-        )
+        res = np.sum(
+            scipy.special.xlogy(self.alphas - 1, value)
+            - scipy.special.gammaln(self.alphas),
+            axis=-1,
+        ) + scipy.special.gammaln(np.sum(self.alphas, axis=-1))
         return res
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -118,7 +118,7 @@ def test_rvs_to_value_vars():
 
 
 def test_rvs_to_value_vars_intermediate_rv():
-    """Test that function replaces values above an intermediate RV. """
+    """Test that function replaces values above an intermediate RV."""
     a = at.random.uniform(0.0, 1.0)
     a.name = "a"
     a.tag.value_var = a_value_var = a.clone()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,4 @@
+import numpy as np
 from aesara.graph.basic import walk
 from aesara.graph.op import HasInnerGraph
 
@@ -20,3 +21,44 @@ def assert_no_rvs(var):
     for v in walk([var], expand, False):
         if v.owner and isinstance(v.owner.op, MeasurableVariable):
             raise AssertionError(f"Variable {v} is a MeasurableVariable")
+
+
+def simulate_poiszero_hmm(
+    N, mu=10.0, pi_0_a=np.r_[1, 1], p_0_a=np.r_[5, 1], p_1_a=np.r_[1, 1], seed=None
+):
+    rng = np.random.default_rng(seed)
+
+    p_0 = rng.dirichlet(p_0_a)
+    p_1 = rng.dirichlet(p_1_a)
+
+    Gammas = np.stack([p_0, p_1])
+    Gammas = np.broadcast_to(Gammas, (N,) + Gammas.shape)
+
+    pi_0 = rng.dirichlet(pi_0_a)
+    s_0 = rng.choice(pi_0.shape[0], p=pi_0)
+    s_tm1 = s_0
+
+    y_samples = np.empty((N,), dtype=np.int64)
+    s_samples = np.empty((N,), dtype=np.int64)
+
+    for i in range(N):
+        s_t = rng.choice(Gammas.shape[-1], p=Gammas[i, s_tm1])
+        s_samples[i] = s_t
+        s_tm1 = s_t
+
+        if s_t == 1:
+            y_samples[i] = rng.poisson(mu)
+        else:
+            y_samples[i] = 0
+
+    sample_point = {
+        "Y_t": y_samples,
+        "p_0": p_0,
+        "p_1": p_1,
+        "S_t": s_samples,
+        "P_tt": Gammas,
+        "S_0": s_0,
+        "pi_0": pi_0,
+    }
+
+    return sample_point


### PR DESCRIPTION
This PR adds HMM constructor functions and an `OpFromGraph` example for a discrete Markov chain.  The latter demonstrates how "composite" measurable `Op`s can be used in AePPL, and the former shows how simple constructor functions that make use of our automatic log-probability derivations can be used to construct interfaces for more advanced models.

Once #75 goes through, we can remove the composite `Op` approach involving `DiscreteMarkovChainFactor`, but&mdash;in the meantime&mdash;it serves as a good example.

Also, these additions will complement an upcoming implementation of https://github.com/aesara-devs/aemcmc/issues/6.