### PR TITLE
Assign IR-related rewrites to `logprob_rewrites_db`

### DIFF
--- a/aeppl/cumsum.py
+++ b/aeppl/cumsum.py
@@ -1,12 +1,12 @@
 from typing import List, Optional
 
 import aesara.tensor as at
-from aesara.graph.opt import local_optimizer
+from aesara.graph.opt import local_optimizer, out2in
 from aesara.tensor.extra_ops import CumOp
 
 from aeppl.abstract import MeasurableVariable, assign_custom_measurable_outputs
 from aeppl.logprob import _logprob, logprob
-from aeppl.opt import PreserveRVMappings, rv_sinking_db
+from aeppl.opt import PreserveRVMappings, logprob_rewrites_db
 
 
 class MeasurableCumsum(CumOp):
@@ -81,4 +81,12 @@ def find_measurable_cumsums(fgraph, node) -> Optional[List[MeasurableCumsum]]:
     return [new_rv]
 
 
-rv_sinking_db.register("find_measurable_cumsums", find_measurable_cumsums, -5, "basic")
+logprob_rewrites_db.register(
+    "find_measurable_cumsums",
+    out2in(
+        find_measurable_cumsums, name="find_measurable_cumsums", ignore_newtrees=True
+    ),
+    0,
+    "basic",
+    "cumsum",
+)

--- a/aeppl/mixture.py
+++ b/aeppl/mixture.py
@@ -5,7 +5,7 @@ import aesara.tensor as at
 from aesara.graph.basic import Apply, Variable
 from aesara.graph.fg import FunctionGraph
 from aesara.graph.op import Op, compute_test_value
-from aesara.graph.opt import local_optimizer, pre_greedy_local_optimizer
+from aesara.graph.opt import local_optimizer, out2in, pre_greedy_local_optimizer
 from aesara.ifelse import ifelse
 from aesara.tensor.basic import Join, MakeVector
 from aesara.tensor.random.opt import local_dimshuffle_rv_lift, local_subtensor_rv_lift
@@ -23,8 +23,8 @@ from aeppl.abstract import MeasurableVariable, assign_custom_measurable_outputs
 from aeppl.logprob import _logprob, logprob
 from aeppl.opt import (
     local_lift_DiracDelta,
+    logprob_rewrites_db,
     naive_bcast_rv_lift,
-    rv_sinking_db,
     subtensor_ops,
 )
 from aeppl.utils import get_constant_value
@@ -369,4 +369,10 @@ def logprob_MixtureRV(
     return logp_val
 
 
-rv_sinking_db.register("mixture_replace", mixture_replace, -5, "basic")
+logprob_rewrites_db.register(
+    "mixture_replace",
+    out2in(mixture_replace, name="mixture_replace", ignore_newtrees=True),
+    0,
+    "basic",
+    "mixture",
+)

--- a/aeppl/scan.py
+++ b/aeppl/scan.py
@@ -506,6 +506,6 @@ logprob_rewrites_db.register(
     "scan",
 )
 
-# Add scan canonicalizations that aren't in the canonicalize DB
+# Add scan canonicalizations that aren't in the canonicalization DB
 logprob_rewrites_db.register("scan_eqopt1", scan_eqopt1, -9, "basic", "scan")
 logprob_rewrites_db.register("scan_eqopt2", scan_eqopt2, -9, "basic", "scan")

--- a/aeppl/truncation.py
+++ b/aeppl/truncation.py
@@ -5,7 +5,7 @@ import aesara.tensor as at
 import numpy as np
 from aesara.graph.basic import Node
 from aesara.graph.fg import FunctionGraph
-from aesara.graph.opt import local_optimizer
+from aesara.graph.opt import local_optimizer, out2in
 from aesara.scalar.basic import Clip
 from aesara.scalar.basic import clip as scalar_clip
 from aesara.tensor.elemwise import Elemwise
@@ -13,7 +13,7 @@ from aesara.tensor.var import TensorConstant
 
 from aeppl.abstract import MeasurableVariable, assign_custom_measurable_outputs
 from aeppl.logprob import CheckParameterValue, _logcdf, _logprob
-from aeppl.opt import rv_sinking_db
+from aeppl.opt import logprob_rewrites_db
 
 
 class CensoredRV(Elemwise):
@@ -72,7 +72,13 @@ def find_censored_rvs(fgraph: FunctionGraph, node: Node) -> Optional[List[Censor
     return [censored_rv]
 
 
-rv_sinking_db.register("find_censored_rvs", find_censored_rvs, -5, "basic")
+logprob_rewrites_db.register(
+    "find_censored_rvs",
+    out2in(find_censored_rvs, name="find_censored_rvs", ignore_newtrees=True),
+    0,
+    "basic",
+    "censoring",
+)
 
 
 @_logprob.register(CensoredRV)


### PR DESCRIPTION
A few of our "measurable" intermediate representation (IR) rewrites were being assigned to `rv_sinking_db`, but that DB is supposed to be specific to random variable sinking.  This PR moves the IR rewrites to `logprob_rewrites_db`&mdash;for the time being.