### PR TITLE
Fix check for missing rv in factorized_joint_logprob

### DIFF
--- a/aeppl/joint_logprob.py
+++ b/aeppl/joint_logprob.py
@@ -122,11 +122,12 @@ def factorized_joint_logprob(
         if not outputs:
             continue
 
-        if warn_missing_rvs and any(o not in updated_rv_values for o in outputs):
-            warnings.warn(
-                "Found a random variable that was neither among the observations "
-                f"nor the conditioned variables: {node.outputs}"
-            )
+        if any(o not in updated_rv_values for o in outputs):
+            if warn_missing_rvs:
+                warnings.warn(
+                    "Found a random variable that was neither among the observations "
+                    f"nor the conditioned variables: {node.outputs}"
+                )
             continue
 
         q_value_vars = [replacements[q_rv_var] for q_rv_var in outputs]

--- a/tests/test_joint_logprob.py
+++ b/tests/test_joint_logprob.py
@@ -1,3 +1,5 @@
+import warnings
+
 import aesara
 import aesara.tensor as at
 import numpy as np
@@ -260,6 +262,10 @@ def test_warn_random_not_found():
 
     with pytest.warns(UserWarning):
         factorized_joint_logprob({y_rv: y_vv})
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        factorized_joint_logprob({y_rv: y_vv}, warn_missing_rvs=False)
 
 
 def test_multiple_rvs_to_same_value_raises():

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -346,6 +346,7 @@ def test_scan_joint_logprob(require_inner_rewrites):
 
 
 @aesara.config.change_flags(compute_test_value="raise")
+@pytest.mark.xfail(reason="see #148")
 def test_initial_values():
     srng = at.random.RandomStream(seed=2320)
 


### PR DESCRIPTION
Currently, random variables that are not provided with their value variable equivalent can result in a `KeyError` in `factorized_joint_logprob` when given `warn_missing_rvs=False`. This error rose when working with a graph corresponding to a Gaussian random walk.

```python
import aesara.tensor as at
from aeppl import factorized_joint_logprob

mu = at.random.normal(loc=2, scale=0.1)
sigma = at.random.gamma(shape=1, rate=1)
innovation_dist = at.random.normal(mu[..., None], sigma[..., None], size=(10,))
rv_out = at.cumsum(innovation_dist, axis=-1) # gaussian random walk
```

The following code chunk yields a `KeyError`:

```python
factorized_joint_logprob(
    {
        rv_out: rv_out.copy(),
    }, 
    extra_rewrites=TransformValuesOpt({}),
    use_jacobian=True,
    warn_missing_rvs=False
)
```

but setting `warn_missing_rvs=True` only issues warnings.

In this PR, so far, I fix the case where users decide to not issue warnings.