### PR TITLE
Introduce graph rewrite for mixture sub-graphs defined via `Switch`

### DIFF
--- a/aeppl/mixture.py
+++ b/aeppl/mixture.py
@@ -11,7 +11,9 @@ from aesara.graph.rewriting.basic import (
     pre_greedy_node_rewriter,
 )
 from aesara.ifelse import ifelse
+from aesara.scalar.basic import Switch
 from aesara.tensor.basic import Join, MakeVector
+from aesara.tensor.elemwise import Elemwise
 from aesara.tensor.random.rewriting import (
     local_dimshuffle_rv_lift,
     local_subtensor_rv_lift,
@@ -19,6 +21,7 @@ from aesara.tensor.random.rewriting import (
 from aesara.tensor.shape import shape_tuple
 from aesara.tensor.subtensor import (
     as_index_literal,
+    as_nontensor_scalar,
     get_canonical_form_slice,
     is_basic_idx,
 )
@@ -251,7 +254,6 @@ def mixture_replace(fgraph, node):
     From these terms, new terms ``Z_rv[i] = mixture_comps[i][i == I_rv]`` are
     created for each ``i`` in ``enumerate(mixture_comps)``.
     """
-
     rv_map_feature = getattr(fgraph, "preserve_rv_mappings", None)
 
     if rv_map_feature is None:
@@ -292,6 +294,56 @@ def mixture_replace(fgraph, node):
     if aesara.config.compute_test_value != "off":
         # We can't use `MixtureRV` to compute a test value; instead, we'll use
         # the original node's test value.
+        if not hasattr(old_mixture_rv.tag, "test_value"):
+            compute_test_value(node)
+
+        new_mixture_rv.tag.test_value = old_mixture_rv.tag.test_value
+
+    if old_mixture_rv.name:
+        new_mixture_rv.name = f"{old_mixture_rv.name}-mixture"
+
+    return [new_mixture_rv]
+
+
+@node_rewriter((Elemwise,))
+def switch_mixture_replace(fgraph, node):
+    rv_map_feature = getattr(fgraph, "preserve_rv_mappings", None)
+
+    if rv_map_feature is None:
+        return None  # pragma: no cover
+
+    if not isinstance(node.op.scalar_op, Switch):
+        return None  # pragma: no cover
+
+    old_mixture_rv = node.default_output()
+    # idx, component_1, component_2 = node.inputs
+
+    mixture_rvs = []
+
+    for component_rv in node.inputs[1:]:
+        if not (
+            component_rv.owner
+            and isinstance(component_rv.owner.op, MeasurableVariable)
+            and component_rv not in rv_map_feature.rv_values
+        ):
+            return None
+        new_node = assign_custom_measurable_outputs(component_rv.owner)
+        out_idx = component_rv.owner.outputs.index(component_rv)
+        new_comp_rv = new_node.outputs[out_idx]
+        mixture_rvs.append(new_comp_rv)
+
+    mix_op = MixtureRV(
+        2,
+        old_mixture_rv.dtype,
+        old_mixture_rv.broadcastable,
+    )
+    new_node = mix_op.make_node(
+        *([NoneConst, as_nontensor_scalar(node.inputs[0])] + mixture_rvs)
+    )
+
+    new_mixture_rv = new_node.default_output()
+
+    if aesara.config.compute_test_value != "off":
         if not hasattr(old_mixture_rv.tag, "test_value"):
             compute_test_value(node)
 
@@ -368,7 +420,8 @@ def logprob_MixtureRV(
 logprob_rewrites_db.register(
     "mixture_replace",
     EquilibriumGraphRewriter(
-        [mixture_replace], max_use_ratio=aesara.config.optdb__max_use_ratio
+        [mixture_replace, switch_mixture_replace],
+        max_use_ratio=aesara.config.optdb__max_use_ratio,
     ),
     0,
     "basic",


### PR DESCRIPTION
Closes #77.

Currently, I am opening this PR to ask for pointers. So far, many lines are copy pasted from `mixture_replace` in the same file. Hopefully, this attempt is on the right track, although it is not working at the moment. The output of a mixture defined by `switch` is showcased in [this gist](https://gist.github.com/larryshamalama/b2e35ec250d6de40974235ed0ee7f53c)