### PR TITLE
Improve numerical stability of censored logps

### DIFF
--- a/aeppl/truncation.py
+++ b/aeppl/truncation.py
@@ -94,7 +94,7 @@ def censor_logprob(op, values, base_rv, lower_bound, upper_bound, **kwargs):
     ):
         is_upper_bounded = True
 
-        logccdf = at.log(1 - at.exp(logcdf))
+        logccdf = at.log1mexp(logcdf)
         # For right censored discrete RVs, we need to add an extra term
         # corresponding to the pmf at the upper bound
         if base_rv_op.dtype == "int64":


### PR DESCRIPTION
Not using the more stable `at.log1mexp` instead of `at.log(1 - at.exp(x))` can lead to numerical issues in the gradient, because the stabilization optimizations are applied after the gradient. eg something like:

```python
import aesara
import aesara.tensor as at
import numpy as np

x = at.scalar("x")
a = at.scalar("a")
b = at.scalar("b")

logcdf = pm.logcdf(pm.Weibull.dist(a, b), x)
logccdf = at.log(1 - at.exp(logcdf))
logccdf2 = at.log1mexp(logcdf)

logcdf.name = "logcdf"
logccdf.name = "logccdf"

func = aesara.function([x, a, b], [at.grad(logccdf, a), at.grad(logccdf2, a)])

func(50, 1, 1)
# [array(-inf), array(-195.60115027)]
```