### PR TITLE
Add a custom metaclass for dynamic type creation of unmeasurable `Op`s

### DIFF
--- a/aeppl/abstract.py
+++ b/aeppl/abstract.py
@@ -69,15 +69,20 @@ def assign_custom_measurable_outputs(
 
     new_node = node.clone()
     op_type = type(new_node.op)
+
+    if op_type in _get_measurable_outputs.registry.keys():
+        if _get_measurable_outputs.registry[op_type] != measurable_outputs_fn:
+            raise ValueError(
+                f"The type {op_type.__name__} with hash value {hash(op_type)} "
+                "has already been dispatched a measurable outputs function."
+            )
+        return node
+
     new_op_type = type(
         f"{type_prefix}{op_type.__name__}", (op_type,), op_type.__dict__.copy()
     )
-
     new_node.op = copy(new_node.op)
     new_node.op.__class__ = new_op_type
-
-    # TODO: The above could be a stand-alone utility function for all sorts of
-    # instance-based dispatching
 
     _get_measurable_outputs.register(new_op_type)(measurable_outputs_fn)
 

--- a/tests/test_abstract.py
+++ b/tests/test_abstract.py
@@ -1,0 +1,94 @@
+import aesara.tensor as at
+import pytest
+from aesara.tensor.random.basic import NormalRV
+
+from aeppl.abstract import (
+    UnmeasurableVariable,
+    _get_measurable_outputs,
+    assign_custom_measurable_outputs,
+    noop_measurable_outputs_fn,
+)
+
+
+def assert_equal_hash(classA, classB):
+    assert hash(classA) == hash(classA.id_obj)
+    assert hash(classB) == hash(classB.id_obj)
+    assert classA == classB
+    assert hash(classA) == hash(classB)
+
+
+@pytest.mark.parametrize(
+    "op, id_obj, class_dict",
+    [
+        (None, None, UnmeasurableVariable.__dict__),
+        (None, (1, 2), UnmeasurableVariable.__dict__),
+        (
+            NormalRV,
+            (NormalRV, noop_measurable_outputs_fn),
+            UnmeasurableVariable.__dict__,
+        ),
+    ],
+)
+def test_unmeasurable_variable_class(op, id_obj, class_dict):
+    A_dict = class_dict.copy()
+    B_dict = class_dict.copy()
+
+    if id_obj is not None:
+        A_dict["id_obj"] = id_obj
+        B_dict["id_obj"] = id_obj
+
+    if op is None:
+        parent_classes = (UnmeasurableVariable,)
+    else:
+        parent_classes = (op, UnmeasurableVariable)
+
+    A = type("A", parent_classes, A_dict)
+    B = type("B", parent_classes, B_dict)
+
+    assert_equal_hash(A, B)
+
+
+def test_unmeasurable_meta_hash_reassignment():
+    A_dict = UnmeasurableVariable.__dict__.copy()
+    B_dict = UnmeasurableVariable.__dict__.copy()
+
+    A_dict["id_obj"] = (1, 2)
+    B_dict["id_obj"] = (1, 3)
+
+    A = type("A", (UnmeasurableVariable,), A_dict)
+    B = type("B", (UnmeasurableVariable,), B_dict)
+
+    assert A != B
+    assert hash(A) != hash(B)
+
+    A.id_obj = (1, 3)
+
+    assert_equal_hash(A, B)
+
+
+def test_assign_custom_measurable_outputs():
+    srng = at.random.RandomStream(seed=2320)
+
+    X_rv = srng.normal(-10.0, 0.1, name="X")
+    Y_rv = srng.normal(10.0, 0.1, name="Y")
+
+    # manually checking assign_custom_measurable_outputs
+    unmeasurable_X = assign_custom_measurable_outputs(X_rv.owner).op
+    unmeasurable_Y = assign_custom_measurable_outputs(Y_rv.owner).op
+
+    assert_equal_hash(unmeasurable_X.__class__, unmeasurable_Y.__class__)
+    assert unmeasurable_X.__class__.__name__.startswith("Unmeasurable")
+    assert unmeasurable_X.__class__ in _get_measurable_outputs.registry
+
+    # passing unmeasurable_X into assign_custom_measurable_outputs does nothing
+
+    unmeas_X_rv = unmeasurable_X(-5, 0.1, name="unmeas_X")
+
+    unmeasurable_X2_node = assign_custom_measurable_outputs(unmeas_X_rv.owner)
+    unmeasurable_X2 = unmeasurable_X2_node.op
+
+    assert unmeasurable_X2_node == unmeas_X_rv.owner
+    assert_equal_hash(unmeasurable_X.__class__, unmeasurable_X2.__class__)
+
+    with pytest.raises(ValueError):
+        assign_custom_measurable_outputs(unmeas_X_rv.owner, lambda x: x)


### PR DESCRIPTION
Closes #157.

This PR adds a check in `assign_custom_measurable_outputs` to verify if the Op name begins with the prefix and if the Op has already been assigned a dispatch `measurable_outputs_fn`.

However, one thing that I noticed is that nodes with the "same" `new_node_type` would go through the function again; in fact, I believe that only their hash values are not identical. Is this an issue? Below is an example of this.

```python
import aesara.tensor as at
from aeppl.opt import construct_ir_fgraph
from aeppl.abstract import _get_measurable_outputs

srng = at.random.RandomStream(seed=2320)

I_rv = srng.bernoulli(0.5, name="I")
X_rv = srng.normal(-10., 0.1, name="X")
Y_rv = srng.normal(10., 0.1, name="Y")

# mixture from stack
Z_rv = at.stack([X_rv, Y_rv])[I_rv]
Z_rv.name = "Z"
z_vv = Z_rv.clone()

i_vv = I_rv.clone()

registered_measurable_ops = list(_get_measurable_outputs.registry.keys())

# op1 and op2 are both UnmeasurableNormalRV
op1, op2 = registered_measurable_ops[5], registered_measurable_ops[6]

op1, op2 # (aesara.tensor.random.basic.UnmeasurableNormalRV,  aesara.tensor.random.basic.UnmeasurableNormalRV)

hash(op1), hash(op2) # (8793444441827, 8793444441922), not the same

hash(_get_measurable_outputs.registry[op1]), hash(_get_measurable_outputs.registry[op2]) # (373950558, 373950558), same hash values
```

Notice that `op1` and `op2` are no longer `UnmeasurableUnmeasurableNormalRV` with this PR.

CC @brandonwillard 