### PR TITLE
Implement measurable `DimShuffle`s

### DIFF
--- a/aeppl/tensor.py
+++ b/aeppl/tensor.py
@@ -98,7 +98,7 @@ def logprob_make_vector(op, values, *base_vars, **kwargs):
 
 
 class MeasurableJoin(Join):
-    """A placeholder used to specify a log-likelihood for a cumsum sub-graph."""
+    """A placeholder used to specify a log-likelihood for a join sub-graph."""
 
 
 MeasurableVariable.register(MeasurableJoin)

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -188,7 +188,6 @@ def test_measurable_join_multivariate(
         y_testval = np.concatenate((base1_testval, base2_testval), axis=axis)
     else:
         y_testval = np.stack((base1_testval, base2_testval), axis=axis)
-    print(base_logps.eval({base1_vv: base1_testval, base2_vv: base2_testval}).shape)
     np.testing.assert_allclose(
         base_logps.eval({base1_vv: base1_testval, base2_vv: base2_testval}),
         y_logp.eval({y_vv: y_testval}),


### PR DESCRIPTION
This PR implements logprob for arbitrary valued DimShuffles, which extends existing coverage of univariate RandomVariable dimshuffled graphs to any univariate and multivariate dimshuffled MeasurableVariables. Related to #150

While https://github.com/aesara-devs/aesara/issues/1113 isn't fixed, it also provides coverage of univariate RandomVariable graphs where dimensions are dropped by DimShuffles