### PR TITLE
Only introduce MeasurableDimShuffles when input is a RandomVariable

### DIFF
--- a/aeppl/tensor.py
+++ b/aeppl/tensor.py
@@ -241,9 +241,17 @@ def find_measurable_dimshuffles(fgraph, node) -> Optional[List[MeasurableDimShuf
 
     base_var = node.inputs[0]
 
+    # We can only apply this rewrite directly to `RandomVariable`s, as those are
+    # the only `Op`s for which we always know the support axis. Other measurable
+    # variables can have arbitrary support axes (e.g., if they contain separate
+    # `MeasurableDimShuffle`s). Most measurable variables with `DimShuffle`s
+    # should still be supported as long as the `DimShuffle`s can be merged/
+    # lifted towards the base RandomVariable.
+    # TODO: If we include the support axis as meta information in each
+    # intermediate MeasurableVariable, we can lift this restriction.
     if not (
         base_var.owner
-        and isinstance(base_var.owner.op, MeasurableVariable)
+        and isinstance(base_var.owner.op, RandomVariable)
         and base_var not in rv_map_feature.rv_values
     ):
         return None  # pragma: no cover


### PR DESCRIPTION
This restricts the behavior introduced by #159 to the cases where the DimShuffle is directly downstream of a RandomVariable.

The new test provides an example of where the previous more liberal introduction of MeasurableDimshuffles would generate the wrong logprob graph due to assuming the support axis is always at the rightmost position. This is not the case in this test, because there is another MeasurableDimshuffle downstream that already shifted the position of the support axis.

Note that most Dimshuffle graphs are still supported as long as Aesara manages to merge/lift the Dimshuffles towards the base RandomVariable. Worth noticing that the existing test case could actually be supported, as it is possible to lift a Dimshuffe by playing with the cumsum axis.

We could include the support axes as meta-information in each intermediate `MeasurableVariable` `Op` so that we don't have to guess/ restrict rewrites. The `ndim_supp` would probably also be a useful meta-information to carry around, although that can be guessed by checking the difference in number of dimensions between the value variable and the respective logp graph.  