### PR TITLE
Do not require dtype to be an Op attribute in Censored

### DIFF
--- a/aeppl/truncation.py
+++ b/aeppl/truncation.py
@@ -97,7 +97,7 @@ def censor_logprob(op, values, base_rv, lower_bound, upper_bound, **kwargs):
         logccdf = at.log1mexp(logcdf)
         # For right censored discrete RVs, we need to add an extra term
         # corresponding to the pmf at the upper bound
-        if base_rv_op.dtype.startswith("int"):
+        if base_rv.dtype.startswith("int"):
             logccdf = at.logaddexp(logccdf, logprob)
 
         logprob = at.switch(


### PR DESCRIPTION
It is a bit too restrictive to require the op to have dtype attribute, instead of just inspecting the variable dtype