### PR TITLE
Raise RuntimeError when requested logprob expressions are not inferred

### DIFF
--- a/aeppl/joint_logprob.py
+++ b/aeppl/joint_logprob.py
@@ -175,6 +175,12 @@ def factorized_joint_logprob(
             for node in io_toposort(graph_inputs(q_logprob_vars), q_logprob_vars):
                 compute_test_value(node)
 
+    missing_value_terms = set(original_values.values()) - set(logprob_vars.keys())
+    if missing_value_terms:
+        raise RuntimeError(
+            f"The logprob terms of the following value variables could not be derived: {missing_value_terms}"
+        )
+
     return logprob_vars
 
 

--- a/tests/test_cumsum.py
+++ b/tests/test_cumsum.py
@@ -60,10 +60,8 @@ def test_destructive_cumsum_fails():
     """Test that a cumsum that mixes dimensions fails"""
     x_rv = at.random.normal(size=(2, 2, 2)).cumsum()
     x_vv = x_rv.clone()
-    with pytest.warns(UserWarning):
-        res = joint_logprob({x_rv: x_vv})
-
-    assert res is None
+    with pytest.raises(RuntimeError, match="could not be derived"):
+        joint_logprob({x_rv: x_vv})
 
 
 def test_deterministic_cumsum():

--- a/tests/test_mixture.py
+++ b/tests/test_mixture.py
@@ -40,8 +40,6 @@ def test_mixture_basics():
 
         return locals()
 
-    # TODO: This should raise explicitly, see #90
-    # with pytest.raises(ValueError, match=".*value variable was specified.*"):
     env = create_mix_model(None, 0)
     X_rv = env["X_rv"]
     I_rv = env["I_rv"]
@@ -52,9 +50,8 @@ def test_mixture_basics():
     x_vv = X_rv.clone()
     x_vv.name = "x"
 
-    assert set(
-        factorized_joint_logprob({M_rv: m_vv, I_rv: i_vv, X_rv: x_vv}).keys()
-    ) == {x_vv, i_vv}
+    with pytest.raises(RuntimeError, match="could not be derived: {m}"):
+        factorized_joint_logprob({M_rv: m_vv, I_rv: i_vv, X_rv: x_vv})
 
     with pytest.raises(NotImplementedError):
         axis_at = at.lscalar("axis")

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -257,18 +257,13 @@ def test_measurable_dimshuffle(ds_order, multivariate):
     )
 
 
-@pytest.mark.xfail(
-    reason="Graphs with DimShuffles that cannot be lifted/merged are currently not supported",
-    raises=AssertionError,
-)
 def test_unmeargeable_dimshuffles():
+    # Test that graphs with DimShuffles that cannot be lifted/merged fail
+
     # Initial support axis is at axis=-1
     x = at.random.dirichlet(
         np.ones((3,)),
-        size=(
-            4,
-            2,
-        ),
+        size=(4, 2),
     )
     # Support axis is now at axis=-2
     y = x.dimshuffle((0, 2, 1))
@@ -279,8 +274,6 @@ def test_unmeargeable_dimshuffles():
     w = z.dimshuffle((1, 0, 2))
 
     w_vv = w.clone()
-    logp = joint_logprob({w: w_vv})
-    assert logp is not None
-
     # TODO: Check that logp is correct if this type of graphs is ever supported
-    raise NotImplementedError("Test for supported behavior not written")
+    with pytest.raises(RuntimeError, match="could not be derived"):
+        joint_logprob({w: w_vv})

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -672,7 +672,8 @@ def test_loc_transform_multiple_rvs_fails1():
 
     y = y_rv.clone()
 
-    assert joint_logprob({y_rv: y}) is None
+    with pytest.raises(RuntimeError, match="could not be derived"):
+        joint_logprob({y_rv: y})
 
 
 def test_nested_loc_transform_multiple_rvs_fails2():
@@ -682,17 +683,20 @@ def test_nested_loc_transform_multiple_rvs_fails2():
 
     y = y_rv.clone()
 
-    assert joint_logprob({y_rv: y}) is None
+    with pytest.raises(RuntimeError, match="could not be derived"):
+        joint_logprob({y_rv: y})
 
 
 def test_discrete_rv_unary_transform_fails():
     y_rv = at.exp(at.random.poisson(1))
-    assert joint_logprob({y_rv: y_rv.clone()}) is None
+    with pytest.raises(RuntimeError, match="could not be derived"):
+        joint_logprob({y_rv: y_rv.clone()})
 
 
 def test_discrete_rv_multinary_transform_fails():
     y_rv = 5 + at.random.poisson(1)
-    assert joint_logprob({y_rv: y_rv.clone()}) is None
+    with pytest.raises(RuntimeError, match="could not be derived"):
+        joint_logprob({y_rv: y_rv.clone()})
 
 
 @pytest.mark.xfail(reason="Check not implemented yet, see #51")

--- a/tests/test_truncation.py
+++ b/tests/test_truncation.py
@@ -1,6 +1,7 @@
 import aesara
 import aesara.tensor as at
 import numpy as np
+import pytest
 import scipy as sp
 import scipy.stats as st
 
@@ -136,8 +137,8 @@ def test_fail_base_and_censored_have_values():
 
     x_vv = x_rv.clone()
     cens_x_vv = cens_x_rv.clone()
-    logp_terms = factorized_joint_logprob({cens_x_rv: cens_x_vv, x_rv: x_vv})
-    assert cens_x_vv not in logp_terms
+    with pytest.raises(RuntimeError, match="could not be derived: {cens_x}"):
+        factorized_joint_logprob({cens_x_rv: cens_x_vv, x_rv: x_vv})
 
 
 def test_fail_multiple_censored_single_base():
@@ -150,8 +151,8 @@ def test_fail_multiple_censored_single_base():
 
     cens_vv1 = cens_rv1.clone()
     cens_vv2 = cens_rv2.clone()
-    logp_terms = factorized_joint_logprob({cens_rv1: cens_vv1, cens_rv2: cens_vv2})
-    assert cens_rv2 not in logp_terms
+    with pytest.raises(RuntimeError, match="could not be derived: {cens2}"):
+        factorized_joint_logprob({cens_rv1: cens_vv1, cens_rv2: cens_vv2})
 
 
 def test_deterministic_clipping():


### PR DESCRIPTION
When some logprob graphs cannot be derived, `factorized_joint_logprob` simply does not include them in the returned dictionary. This can be confusing, specially because cannot be expected to know what derivations aeppl is capable of doing in advance. This PR suggests raising explicitly whenever a requested logprob expression is missing by the end. Closes #90 

Before:

```python
import aesara.tensor as at
from aeppl import factorized_joint_logprob

x = at.random.normal(name="x")
y = at.cos(at.random.normal())
y.name = "y"

x_vv = x.clone()
y_vv = y.clone()

# Aeppl does not know the logprob for y
print(factorized_joint_logprob({x: x_vv, y: y_vv}))  # {x: x_logprob}
```

After:

```python
import aesara.tensor as at
from aeppl import factorized_joint_logprob

x = at.random.normal(name="x")
y = at.cos(at.random.normal())
y.name = "y"

x_vv = x.clone()
y_vv = y.clone()

# Aeppl does not know how to derive the logprob for y
# RuntimeError: The logprob terms of the following value variables could not be derived: {y}
factorized_joint_logprob({x: x_vv, y: y_vv})
```

There is a `UserWarning` that is issued by default when the normal variable in the graph of `y` is found, but it is not as informative to the user, and is not specific to failed derivations either.
