### PR TITLE
Fix bug in logprob_dimshuffle

### DIFF
--- a/aeppl/joint_logprob.py
+++ b/aeppl/joint_logprob.py
@@ -18,6 +18,7 @@ from aeppl.utils import rvs_to_value_vars
 def factorized_joint_logprob(
     rv_values: Dict[TensorVariable, TensorVariable],
     warn_missing_rvs: bool = True,
+    ir_rewriter: Optional[GraphRewriter] = None,
     extra_rewrites: Optional[Union[GraphRewriter, NodeRewriter]] = None,
     **kwargs,
 ) -> Dict[TensorVariable, TensorVariable]:
@@ -66,6 +67,8 @@ def factorized_joint_logprob(
         When ``True``, issue a warning when a `RandomVariable` is found in
         the graph and doesn't have a corresponding value variable specified in
         `rv_values`.
+    ir_rewriter
+        Rewriter that produces the intermediate representation of Measurable Variables.
     extra_rewrites
         Extra rewrites to be applied (e.g. reparameterizations, transforms,
         etc.)
@@ -76,7 +79,7 @@ def factorized_joint_logprob(
     from the respective `RandomVariable`.
 
     """
-    fgraph, rv_values, _ = construct_ir_fgraph(rv_values)
+    fgraph, rv_values, _ = construct_ir_fgraph(rv_values, ir_rewriter=ir_rewriter)
 
     if extra_rewrites is not None:
         extra_rewrites.rewrite(fgraph)

--- a/aeppl/tensor.py
+++ b/aeppl/tensor.py
@@ -210,10 +210,11 @@ def logprob_dimshuffle(op, values, base_var, **kwargs):
         undo_ds.insert(dropped_dim, "x")
     value = value.dimshuffle(undo_ds)
 
-    # Then, reshuffle remaining dims
-    undo_ds = op.shuffle
+    # Then, unshuffle remaining dims
+    original_shuffle = list(op.shuffle)
     for dropped_dim in dropped_dims:
-        undo_ds.insert(dropped_dim, dropped_dim)
+        original_shuffle.insert(dropped_dim, dropped_dim)
+    undo_ds = [original_shuffle.index(i) for i in range(len(original_shuffle))]
     value = value.dimshuffle(undo_ds)
 
     raw_logp = logprob(base_var, value)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     install_requires=[
         "numpy>=1.18.1",
         "scipy>=1.4.0",
-        "aesara >= 2.8.0",
+        "aesara >= 2.8.5",
     ],
     tests_require=["pytest"],
     long_description=open("README.rst").read() if exists("README.rst") else "",


### PR DESCRIPTION
The logic to unshuffle the dimensions was wrong, but none of the pre-existing tests would reveal it. 

The new test condition fails without the fix in multivariate test, and would also have failed in the univariate one, if `local_dimshuffle_rv_lift` was disabled.

Is there a way to disable the `local_dimshuffle_rv_lift` rewrite for the purposes of the test?