### PR TITLE
Fixes in the LaTeX pretty-printer

### DIFF
--- a/aeppl/printing.py
+++ b/aeppl/printing.py
@@ -101,7 +101,7 @@ class RandomVariablePrinter:
                 "not the result of a RandomVariable operation" % self.name
             )
 
-        op_name = self.name or getattr(node.op, "print_name", None)
+        op_name = self.name or getattr(node.op, "_print_name", None)
         op_name = op_name or getattr(node.op, "name", None)
 
         if op_name is None:  # pragma: no cover

--- a/aeppl/printing.py
+++ b/aeppl/printing.py
@@ -130,7 +130,6 @@ class RandomVariablePrinter:
             dummy_out.orig_var = output
 
             var_name = pprinter.process(dummy_out, pstate)
-
             if output_latex:
                 dist_format = "%s \\sim %s\\left(%s\\right)"
             else:
@@ -138,6 +137,7 @@ class RandomVariablePrinter:
 
             # Get the shape info for our dummy symbol, if available,
             # and append it to the distribution definition.
+            # TODO: Propagate this change upstream in Aesara's pretty printer.
             if "shape_strings" in preamble_dict:
                 shape_info_str = preamble_dict["shape_strings"].pop(dummy_out)
                 shape_info_str = shape_info_str.lstrip(var_name)
@@ -151,6 +151,17 @@ class RandomVariablePrinter:
                 self.process_param(i, pprinter.process(p, pstate), pstate)
                 for i, p in enumerate(dist_params)
             ]
+
+            # We remove trailing zeros and limit the number of decimals
+            # on floats
+            formatted_params = []
+            for i, p in enumerate(dist_params):
+                f_param = self.process_param(i, pprinter.process(p, pstate), pstate)
+                try:
+                    f_param = f"{float(f_param):2g}".strip()
+                except ValueError:
+                    pass
+                formatted_params.append(f_param)
 
             dist_def_str = dist_format % (
                 var_name,

--- a/aeppl/printing.py
+++ b/aeppl/printing.py
@@ -561,9 +561,12 @@ class PreamblePPrinter(PPrinter):
             preamble_lines.append(newline_str.join(comma_str.join(z) for z in v_new))
 
         if preamble_lines and latex_out:
-            preamble_body = newline_str.join(preamble_lines)
-            preamble_str = f"\\begin{{gathered}}\n{textwrap.indent(preamble_body, indent_str)}\n\\end{{gathered}}"
-            res = newline_str.join([preamble_str] + body_strs)
+            preamble_body = newline_str.join(preamble_lines + body_strs)
+            preamble_str = (
+                f"\\begin{{gathered}}\n{textwrap.indent(preamble_body, indent_str)}"
+                f"\n\\end{{gathered}}"
+            )
+            res = newline_str.join([preamble_str])
         else:
             res = newline_str.join(preamble_lines + body_strs)
 

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -112,9 +112,9 @@ def test_tex_print():
         b \in \mathbb{R}, \,\mu \in \mathbb{R}, \,\sigma \in \mathbb{R}
         \\
         a \sim \operatorname{N}\left(\mu, {\sigma}^{2}\right)\,  \in \mathbb{R}
+        \\
+        (b \odot a)
       \end{gathered}
-      \\
-      (b \odot a)
     \end{equation}
     """
     )
@@ -130,9 +130,9 @@ def test_tex_print():
         b \in \mathbb{R}, \,\mu \in \mathbb{R}, \,\sigma \in \mathbb{R}
         \\
         X \sim \operatorname{N}\left(\mu, {\sigma}^{2}\right)\,  \in \mathbb{R}^{2 \times 1}
+        \\
+        (b \odot X)
       \end{gathered}
-      \\
-      (b \odot X)
     \end{equation}
     """
     )
@@ -157,9 +157,9 @@ def test_tex_print():
         a \sim \operatorname{N}\left(\mu_2, {\sigma_2}^{2}\right)\,  \in \mathbb{R}
         \\
         d \sim \operatorname{N}\left((M \odot a), {\sigma}^{2}\right)\,  \in \mathbb{R}^{N^{d}_{0} \times N^{d}_{1}}
+        \\
+        ((M \odot a) \odot ((b \odot d) + c))
       \end{gathered}
-      \\
-      ((M \odot a) \odot ((b \odot d) + c))
     \end{equation}
     """
     )
@@ -170,9 +170,9 @@ def test_tex_print():
     \begin{equation}
       \begin{gathered}
         b \in \mathbb{Z}, \,c \in \mathbb{Z}, \,M \in \mathbb{R}^{N^{M}_{0} \times N^{M}_{1}}
+        \\
+        M\left[b, \,c\right]
       \end{gathered}
-      \\
-      M\left[b, \,c\right]
     \end{equation}
     """
     )
@@ -187,9 +187,9 @@ def test_tex_print():
     \begin{equation}
       \begin{gathered}
         M \in \mathbb{R}^{N^{M}_{0} \times N^{M}_{1}}
+        \\
+        M\left[1\right]
       \end{gathered}
-      \\
-      M\left[1\right]
     \end{equation}
     """
     )
@@ -200,9 +200,9 @@ def test_tex_print():
     \begin{equation}
       \begin{gathered}
         M \in \mathbb{N}^{N^{M}_{0}}
+        \\
+        M\left[2:4:0\right]
       \end{gathered}
-      \\
-      M\left[2:4:0\right]
     \end{equation}
     """
     )
@@ -220,9 +220,9 @@ def test_tex_print():
         S \sim \operatorname{Gamma^{-1}}\left(0.5, 0.5\right)\,  \in \mathbb{R}
         \\
         Y \sim \operatorname{N}\left(T, {\sqrt{S}}^{2}\right)\,  \in \mathbb{R}
+        \\
+        Y
       \end{gathered}
-      \\
-      Y
     \end{equation}
     """
     )
@@ -242,9 +242,9 @@ def test_tex_print_support_dimension():
         U \sim \operatorname{U}\left(1, 1\right)\,  \in \left[0, 1\right]
         \\
         T \sim \operatorname{C^{+}}\left(1, 1\right)\,  \in \mathbb{R}^{+}
+        \\
+        T
       \end{gathered}
-      \\
-      T
     \end{equation}
     """
     )

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -215,7 +215,7 @@ def test_tex_print():
         r"""
     \begin{equation}
       \begin{gathered}
-        T \sim \operatorname{C^{+}}\left(1.0, 1.0\right)\,  \in \mathbb{R}
+        T \sim \operatorname{C^{+}}\left(1, 1\right)\,  \in \mathbb{R}
         \\
         S \sim \operatorname{Gamma^{-1}}\left(0.5, 0.5\right)\,  \in \mathbb{R}
         \\
@@ -239,9 +239,9 @@ def test_tex_print_support_dimension():
         r"""
     \begin{equation}
       \begin{gathered}
-        U \sim \operatorname{U}\left(1.0, 1.0\right)\,  \in \left[0, 1\right]
+        U \sim \operatorname{U}\left(1, 1\right)\,  \in \left[0, 1\right]
         \\
-        T \sim \operatorname{C^{+}}\left(1.0, 1.0\right)\,  \in \mathbb{R}^{+}
+        T \sim \operatorname{C^{+}}\left(1, 1\right)\,  \in \mathbb{R}^{+}
       \end{gathered}
       \\
       T


### PR DESCRIPTION
- [x] Use the `RandomVariable`s' `_op_name` attribute for pretty printing
- [x] Move the graph's output inside `gathered`
- [x] Remove the numbers' trailing zeros using `{0:g}`

Closes #187. Once we have support information in AePPL we can also change this in the pretty printer. I left a test that I marked as `xfail` as a reminder.

