### PR TITLE
Refactor `MeasurableElemwise` and its use

### DIFF
--- a/aeppl/abstract.py
+++ b/aeppl/abstract.py
@@ -1,7 +1,7 @@
 import abc
 from copy import copy
 from functools import singledispatch
-from typing import Callable, List, Tuple
+from typing import Callable, List
 
 from aesara.graph.basic import Apply, Variable
 from aesara.graph.op import Op
@@ -121,16 +121,6 @@ def assign_custom_measurable_outputs(
 
 class MeasurableElemwise(Elemwise):
     """Base class for Measurable Elemwise variables"""
-
-    valid_scalar_types: Tuple[MetaType, ...] = ()
-
-    def __init__(self, scalar_op, *args, **kwargs):
-        if not isinstance(scalar_op, self.valid_scalar_types):
-            raise TypeError(
-                f"scalar_op {scalar_op} is not valid for class {self.__class__}. "
-                f"Acceptable types are {self.valid_scalar_types}"
-            )
-        super().__init__(scalar_op, *args, **kwargs)
 
 
 MeasurableVariable.register(MeasurableElemwise)

--- a/aeppl/cumsum.py
+++ b/aeppl/cumsum.py
@@ -83,7 +83,6 @@ def find_measurable_cumsums(fgraph, node) -> Optional[List[MeasurableCumsum]]:
 measurable_ir_rewrites_db.register(
     "find_measurable_cumsums",
     find_measurable_cumsums,
-    0,
     "basic",
     "cumsum",
 )

--- a/aeppl/joint_logprob.py
+++ b/aeppl/joint_logprob.py
@@ -102,7 +102,7 @@ def conditional_logprob(
             vv.name = f"{rv.name}_vv"
         original_rv_values[rv] = vv
 
-    # Value variables are not cloned when constructing the conditional log-proprobability
+    # Value variables are not cloned when constructing the conditional log-probability
     # graphs. We can thus use them to recover the original random variables to index the
     # maps to the logprob graphs and value variables before returning them.
     rv_values = {**original_rv_values, **realized}

--- a/aeppl/mixture.py
+++ b/aeppl/mixture.py
@@ -423,7 +423,6 @@ logprob_rewrites_db.register(
         [mixture_replace, switch_mixture_replace],
         max_use_ratio=aesara.config.optdb__max_use_ratio,
     ),
-    0,
     "basic",
     "mixture",
 )

--- a/aeppl/rewriting.py
+++ b/aeppl/rewriting.py
@@ -326,6 +326,6 @@ def construct_ir_fgraph(
         new_to_old = tuple(
             (v, k) for k, v in rv_remapper.measurable_conversions.items()
         )
-        fgraph.replace_all(new_to_old)
+        fgraph.replace_all(new_to_old, reason="construct_ir_fgraph")
 
     return fgraph, rv_values, memo

--- a/aeppl/rewriting.py
+++ b/aeppl/rewriting.py
@@ -218,9 +218,7 @@ def incsubtensor_rv_replace(fgraph, node):
 
 logprob_rewrites_db = SequenceDB()
 logprob_rewrites_db.name = "logprob_rewrites_db"
-logprob_rewrites_db.register(
-    "pre-canonicalize", optdb.query("+canonicalize"), -10, "basic"
-)
+logprob_rewrites_db.register("pre-canonicalize", optdb.query("+canonicalize"), "basic")
 
 # These rewrites convert un-measurable variables into their measurable forms,
 # but they need to be reapplied, because some of the measurable forms require
@@ -229,22 +227,18 @@ measurable_ir_rewrites_db = NoCallbackEquilibriumDB()
 measurable_ir_rewrites_db.name = "measurable_ir_rewrites_db"
 
 logprob_rewrites_db.register(
-    "measurable_ir_rewrites", measurable_ir_rewrites_db, -10, "basic"
+    "measurable_ir_rewrites", measurable_ir_rewrites_db, "basic"
 )
 
 # These rewrites push random/measurable variables "down", making them closer to
 # (or eventually) the graph outputs.  Often this is done by lifting other `Op`s
 # "up" through the random/measurable variables and into their inputs.
+measurable_ir_rewrites_db.register("subtensor_lift", local_subtensor_rv_lift, "basic")
 measurable_ir_rewrites_db.register(
-    "subtensor_lift", local_subtensor_rv_lift, -5, "basic"
-)
-measurable_ir_rewrites_db.register(
-    "incsubtensor_lift", incsubtensor_rv_replace, -5, "basic"
+    "incsubtensor_lift", incsubtensor_rv_replace, "basic"
 )
 
-logprob_rewrites_db.register(
-    "post-canonicalize", optdb.query("+canonicalize"), 10, "basic"
-)
+logprob_rewrites_db.register("post-canonicalize", optdb.query("+canonicalize"), "basic")
 
 
 def construct_ir_fgraph(

--- a/aeppl/scan.py
+++ b/aeppl/scan.py
@@ -513,7 +513,6 @@ measurable_ir_rewrites_db.register(
     # out2in(
     #     add_opts_to_inner_graphs, name="add_opts_to_inner_graphs", ignore_newtrees=True
     # ),
-    -100,
     "basic",
     "scan",
 )
@@ -521,11 +520,10 @@ measurable_ir_rewrites_db.register(
 measurable_ir_rewrites_db.register(
     "find_measurable_scans",
     find_measurable_scans,
-    0,
     "basic",
     "scan",
 )
 
 # Add scan canonicalizations that aren't in the canonicalization DB
-logprob_rewrites_db.register("scan_eqopt1", scan_eqopt1, -9, "basic", "scan")
-logprob_rewrites_db.register("scan_eqopt2", scan_eqopt2, -9, "basic", "scan")
+logprob_rewrites_db.register("scan_eqopt1", scan_eqopt1, "basic", "scan")
+logprob_rewrites_db.register("scan_eqopt2", scan_eqopt2, "basic", "scan")

--- a/aeppl/tensor.py
+++ b/aeppl/tensor.py
@@ -273,25 +273,24 @@ def find_measurable_dimshuffles(fgraph, node) -> Optional[List[MeasurableDimShuf
 
 
 measurable_ir_rewrites_db.register(
-    "dimshuffle_lift", local_dimshuffle_rv_lift, -5, "basic", "tensor"
+    "dimshuffle_lift", local_dimshuffle_rv_lift, "basic", "tensor"
 )
 
 
 # We register this later than `dimshuffle_lift` so that it is only applied as a fallback
 measurable_ir_rewrites_db.register(
-    "find_measurable_dimshuffles", find_measurable_dimshuffles, 0, "basic", "tensor"
+    "find_measurable_dimshuffles", find_measurable_dimshuffles, "basic", "tensor"
 )
 
 
 measurable_ir_rewrites_db.register(
-    "broadcast_to_lift", naive_bcast_rv_lift, -5, "basic", "tensor"
+    "broadcast_to_lift", naive_bcast_rv_lift, "basic", "tensor"
 )
 
 
 measurable_ir_rewrites_db.register(
     "find_measurable_stacks",
     find_measurable_stacks,
-    0,
     "basic",
     "tensor",
 )

--- a/aeppl/utils.py
+++ b/aeppl/utils.py
@@ -188,7 +188,9 @@ def replace_rvs_in_graphs(
             clone=False,
         )
 
-        fg.replace_all(replacements.items(), import_missing=True)
+        fg.replace_all(
+            replacements.items(), import_missing=True, reason="replace_rvs_in_graphs"
+        )
 
         graphs = list(fg.outputs)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ omit =
     tests/*
 exclude_lines =
     pragma: no cover
+    if TYPE_CHECKING:
 show_missing = 1
 
 [isort]

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         "numpy>=1.18.1",
         "scipy>=1.4.0",
         "aesara >= 2.8.8",
+        "typing_extensions",
     ],
     tests_require=["pytest"],
     long_description=open("README.rst").read() if exists("README.rst") else "",

--- a/tests/test_abstract.py
+++ b/tests/test_abstract.py
@@ -1,13 +1,8 @@
-import re
-
 import aesara.tensor as at
 import pytest
-from aesara.scalar import Exp, exp
 from aesara.tensor.random.basic import NormalRV
 
 from aeppl.abstract import (
-    MeasurableElemwise,
-    MeasurableVariable,
     UnmeasurableVariable,
     _get_measurable_outputs,
     assign_custom_measurable_outputs,
@@ -97,16 +92,3 @@ def test_assign_custom_measurable_outputs():
 
     with pytest.raises(ValueError):
         assign_custom_measurable_outputs(unmeas_X_rv.owner, lambda x: x)
-
-
-def test_measurable_elemwise():
-    # Default does not accept any scalar_op
-    with pytest.raises(TypeError, match=re.escape("scalar_op exp is not valid")):
-        MeasurableElemwise(exp)
-
-    class TestMeasurableElemwise(MeasurableElemwise):
-        valid_scalar_types = (Exp,)
-
-    measurable_exp_op = TestMeasurableElemwise(scalar_op=exp)
-    measurable_exp = measurable_exp_op(0.0)
-    assert isinstance(measurable_exp.owner.op, MeasurableVariable)

--- a/tests/test_censoring.py
+++ b/tests/test_censoring.py
@@ -131,7 +131,7 @@ def test_fail_multiple_clip_single_base():
     cens_rv2 = at.clip(base_rv, -1, 1)
     cens_rv2.name = "cens2"
 
-    with pytest.raises(RuntimeError, match="could not be derived: {cens2}"):
+    with pytest.raises(RuntimeError, match=r"could not be derived: {cens\d}"):
         conditional_logprob(cens_rv1, cens_rv2)
 
 


### PR DESCRIPTION
This PR refactors the design of `MeasurableElemwise` and the rewrites that use it (i.e. the changes mostly introduced by https://github.com/aesara-devs/aeppl/pull/26).

These changes make it easier for others to extend the coverage of measurable `Elemwise` transforms using basic rewrite DB registration.  They also put each transformation rewrite under the management of Aesara's rewrite system independently, which means that they can be applied more efficiently (e.g. hash-based lookups on distinct `Op` instances) and their application can be enabled/disabled and tracked with more granularity&mdash;among other things.

The additions in #144 have also been added.

- [x] Consider replacing the negation and subtraction rewrites with direct transform-constructing rewrites to avoid breaking canonicalization (see the comments in #144)


Closes #170