### PR TITLE
Use `RandomStream` in examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,10 +28,11 @@ containing Aesara ``RandomVariable``\s:
 
   from aeppl import joint_logprob, pprint
 
+  srng = at.random.RandomStream()
 
   # A simple scale mixture model
-  S_rv = at.random.invgamma(0.5, 0.5)
-  Y_rv = at.random.normal(0.0, at.sqrt(S_rv))
+  S_rv = srng.invgamma(0.5, 0.5)
+  Y_rv = srng.normal(0.0, at.sqrt(S_rv))
 
   # Compute the joint log-probability
   logprob, (y, s) = joint_logprob(Y_rv, S_rv)
@@ -94,8 +95,8 @@ Joint log-probabilities can be computed for some terms that are *derived* from
 .. code-block:: python
 
   # Create a switching model from a Bernoulli distributed index
-  Z_rv = at.random.normal([-100, 100], 1.0, name="Z")
-  I_rv = at.random.bernoulli(0.5, name="I")
+  Z_rv = srng.normal([-100, 100], 1.0, name="Z")
+  I_rv = srng.bernoulli(0.5, name="I")
 
   M_rv = Z_rv[I_rv]
   M_rv.name = "M"

--- a/aeppl/joint_logprob.py
+++ b/aeppl/joint_logprob.py
@@ -31,7 +31,8 @@ def conditional_logprob(
 
         import aesara.tensor as at
 
-        srng = at.random.RandomStream(0)
+        srng = at.random.RandomStream()
+
         sigma2_rv = srng.invgamma(0.5, 0.5)
         Y_rv = srng.normal(0, at.sqrt(sigma2_rv))
 
@@ -267,7 +268,7 @@ def joint_logprob(
 
         import aesara.tensor as at
 
-        srng = at.random.RandomStream(0)
+        srng = at.random.RandomStream()
         sigma2_rv = srng.invgamma(0.5, 0.5)
         Y_rv = srng.normal(0, at.sqrt(sigma2_rv))
 

--- a/aeppl/printing.py
+++ b/aeppl/printing.py
@@ -417,7 +417,8 @@ class PreamblePPrinter(PPrinter):
     -------
     >>> import aesara.tensor as at
     >>> from aeppl.printing import pprint
-    >>> X_rv = at.random.normal(at.scalar('\\mu'), at.scalar('\\sigma'), name='X')
+    >>> srng = at.random.RandomStream()
+    >>> X_rv = srng.normal(at.scalar('\\mu'), at.scalar('\\sigma'), name='X')
     >>> print(pprint(X_rv))
     \\mu in R
     \\sigma in R

--- a/docs/source/api/distributions.rst
+++ b/docs/source/api/distributions.rst
@@ -11,7 +11,7 @@ The :py:func:`aeppl.logprob.logprob` function can be called on any random variab
    import aesara.tensor as at
    from aeppl.logprob import _logprob
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    mu = at.scalar("mu")
    sigma = at.scalar("sigma")
@@ -29,7 +29,7 @@ Documentation for the Aesara implementation can be found here: :external:py:clas
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    p = at.scalar("p")
    x_rv = snrg.bernoulli(p)
@@ -43,7 +43,7 @@ Documentation for the Aesara implementation can be found here: :external:py:clas
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    a = at.scalar("a")
    b = at.scalar("b")
@@ -59,7 +59,7 @@ Documentation for the Aesara implementation can be found here: :external:py:clas
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    n = at.iscalar("n")
    a = at.scalar("a")
@@ -76,7 +76,7 @@ Documentation for the Aesara implementation can be found here: :external:py:clas
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    n = at.iscalar("n")
    p = at.scalar("p")
@@ -92,7 +92,7 @@ Documentation for the Aesara implementation can be found here: :external:py:clas
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    loc = at.scalar("loc")
    scale = at.scalar("scale")
@@ -107,7 +107,7 @@ Documentation for the Aesara implementation can be found here: :external:py:clas
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    p = at.vector("p")
    x_rv = snrg.categorical(p)
@@ -121,7 +121,7 @@ Documentation for the Aesara implementation can be found here: :external:py:clas
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    df = at.scalar("df")
    x_rv = snrg.chisquare(df)
@@ -148,7 +148,7 @@ Documentation for the Aesara implementation can be found here: :external:py:clas
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    alpha = at.vector("alpha")
    x_rv = snrg.dirichlet(alpha)
@@ -167,7 +167,7 @@ Documentation for the Aesara implementation can be found here: :external:py:clas
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    beta = at.scalar("beta")
    x_rv = snrg.exponential(beta)
@@ -181,7 +181,7 @@ Documentation for the Aesara implementation can be found here: :external:py:clas
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    alpha = at.scalar('alpha')
    beta = at.scalar('beta')
@@ -196,7 +196,7 @@ Documentation for the Aesara implementation can be found here: :external:py:clas
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    p = at.scalar("p")
    x_rv = snrg.geometric(p)
@@ -210,7 +210,7 @@ Documentation for the Aesara implementation can be found here: :external:py:clas
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    mu = at.scalar('mu')
    beta = at.scalar('beta')
@@ -225,7 +225,7 @@ Documentation for the Aesara implementation can be found here: :external:py:clas
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    x0 = at.scalar('x0')
    gamma = at.scalar('gamma')
@@ -240,7 +240,7 @@ Documentation for the Aesara implementation can be found here: :external:py:clas
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    mu = at.scalar('mu')
    sigma = at.scalar('sigma')
@@ -255,7 +255,7 @@ Documentation for the Aesara implementation can be found here: :external:py:clas
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    ngood = at.scalar("ngood")
    nbad = at.scalar("nbad")
@@ -271,7 +271,7 @@ Documentation for the Aesara implementation can be found here: :external:py:clas
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    alpha = at.scalar('alpha')
    beta = at.scalar('beta')
@@ -286,7 +286,7 @@ Documentation for the Aesara implementation can be found here: :external:py:clas
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    mu = at.scalar("mu")
    lmbda = at.scalar("lambda")
@@ -301,7 +301,7 @@ Documentation for the Aesara implementation can be found here: :external:py:clas
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    mu = at.scalar("mu")
    s = at.scalar("s")
@@ -316,7 +316,7 @@ Documentation for the Aesara implementation can be found here: :external:py:clas
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    mu = at.scalar("mu")
    sigma = at.scalar("sigma")
@@ -331,7 +331,7 @@ Documentation for the Aesara implementation can be found here: :external:py:clas
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    n = at.iscalar("n")
    p = at.vector("p")
@@ -346,7 +346,7 @@ Documentation for the Aesara implementation can be found here: :external:py:clas
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    mu = at.vector('mu')
    Sigma = at.matrix('sigma')
@@ -362,7 +362,7 @@ Documentation for the Aesara implementation can be found here: :external:py:clas
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    n = at.iscalar("n")
    p = at.scalar("p")
@@ -377,7 +377,7 @@ Documentation for the Aesara implementation can be found here: :external:py:clas
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    mu = at.scalar('mu')
    sigma = at.scalar('sigma')
@@ -392,7 +392,7 @@ Documentation for the Aesara implementation can be found here: :external:py:clas
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    b = at.scalar("b")
    scale = at.scalar("scale")
@@ -407,7 +407,7 @@ Documentation for the Aesara implementation can be found here: :external:py:clas
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    lmbda = at.scalar("lambda")
    x_rv = snrg.poisson(lmbda)
@@ -421,7 +421,7 @@ Documentation for the Aesara implementation can be found here: :external:py:clas
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    df = at.scalar('df')
    loc = at.scalar('loc')
@@ -437,7 +437,7 @@ Documentation for the Aesara implementation can be found here: :external:py:clas
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    left = at.scalar('left')
    mode = at.scalar('mode')
@@ -453,7 +453,7 @@ Documentation for the Aesara implementation can be found here: :external:py:clas
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    low = at.scalar('low')
    high = at.scalar('high')
@@ -468,7 +468,7 @@ Documentation for the Aesara implementation can be found here: :external:py:clas
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    mu = at.scalar('mu')
    kappa = at.scalar('kappa')
@@ -483,7 +483,7 @@ Documentation for the Aesara implementation can be found here: :external:py:clas
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    mu = at.scalar('mu')
    lmbda = at.scalar('lambda')
@@ -499,7 +499,7 @@ Documentation for the Aesara implementation can be found here: :external:py:clas
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    k = at.scalar('k')
    x_rv = srng.weibull(k)

--- a/docs/source/api/mixtures.rst
+++ b/docs/source/api/mixtures.rst
@@ -10,7 +10,7 @@ By creating an array of random variables and indexing it with a random variable:
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    w_rv = srng.normal(-2, 1)
    x_rv = srng.normal(0, 1)
@@ -27,7 +27,7 @@ Using `aesara.tensor.switch`:
 
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    x_rv = srng.normal(0, 1)
    y_rv = srng.normal(2, 1)

--- a/docs/source/api/scan.rst
+++ b/docs/source/api/scan.rst
@@ -10,7 +10,7 @@ AePPL can compute the log-density of measures defined as the output of an `aesar
    import aesara.tensor as at
    import numpy as np
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    p = np.array([0.9, 0.1])
    S_0_rv = srng.categorical(p)

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -16,7 +16,7 @@ You can define mixture models very naturally by specifying their generative proc
     import aesara.tensor as at
     import numpy as np
 
-    srng = at.random.RandomStream(0)
+    srng = at.random.RandomStream()
 
     loc = np.array([-2, 0, 3.2, 2.5])
     scale = np.array([1.2, 1, 5, 2.8])
@@ -44,7 +44,7 @@ Stochastic volatility model
     import aesara
     import aesara.tensor as at
 
-    srng = at.random.RandomStream(0)
+    srng = at.random.RandomStream()
     sigma_rv = srng.exponential(1)
     nu_rv = srng.exponential(1)
 
@@ -87,7 +87,7 @@ This example shows how to deal with improper priors and specify observed variabl
     b = at.scalar("b")
     hyperprior = at.pow(a + b, -2.5)
 
-    srng = at.random.RandomStream(0)
+    srng = at.random.RandomStream()
     theta_rv = srng.beta(a, b, size=(n_trials,))
     Y_rv = srng.binom(theta, n_rats)
 
@@ -107,7 +107,7 @@ Sparse Regression
     import numpy as np
 
 
-    srng = at.random.RandomStream(0)
+    srng = at.random.RandomStream()
 
     X = at.matrix("X")
 
@@ -194,7 +194,7 @@ The `PERT distribution <https://en.wikipedia.org/wiki/PERT_distribution>`_, for 
     import aesara
     import aesara.tensor as at
 
-    srng = at.random.RandomStream(0)
+    srng = at.random.RandomStream()
 
     def pert(srng, a, b, c):
         r"""Construct a random variable that is PERT-distributed."""

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,7 +24,7 @@ Example
    import aesara
    import aesara.tensor as at
 
-   srng = at.random.RandomStream(0)
+   srng = at.random.RandomStream()
 
    S_rv = srng.invgamma(0.5, 0.5)
    Y_rv = srng.normal(0.0, at.sqrt(S_rv))

--- a/tests/test_mixture.py
+++ b/tests/test_mixture.py
@@ -729,7 +729,7 @@ def test_switch_mixture():
 
 
 def test_dirac_delta_mixture_dtype():
-    srng = at.random.RandomStream(0)
+    srng = at.random.RandomStream()
 
     p = at.scalar("p")
     I_rv = srng.bernoulli(p)


### PR DESCRIPTION
This PR changes direct uses of `aesara.tensor.random` `Op`s to use `RandomStream` instead.