### PR TITLE
Update GitHub Action versions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,7 +22,7 @@ jobs:
         run: python -m build --sdist .
         env:
           BUILD_AEPPL_NIGHTLY: true
-      - uses: pypa/gh-action-pypi-publish@v1.4.2
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.nightly_pypi_secret }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
       - name: Install dependencies

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,7 +8,7 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v2

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -21,7 +21,7 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v2

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
       - name: Build the sdist and the wheel

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           name: artifact
           path: dist
-      - uses: pypa/gh-action-pypi-publish@master
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.pypi_secret }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
     if: ${{ needs.changes.outputs.changes == 'true' }}
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
     - uses: pre-commit/action@v2.0.0
 
   test:
@@ -148,7 +148,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     outputs:
       changes: ${{ steps.changes.outputs.src }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: dorny/paths-filter@v2
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ needs.changes.outputs.changes == 'true' }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-python@v2
     - uses: pre-commit/action@v2.0.0
 
@@ -74,7 +74,7 @@ jobs:
           - "tests --ignore=tests/test_logprob.py"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
@@ -145,7 +145,7 @@ jobs:
     needs: [changes, all-checks]
     if: ${{ needs.changes.outputs.changes == 'true' && needs.all-checks.result == 'success' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
         uses: actions/setup-python@v1

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -5,7 +5,7 @@ import pytest
 import scipy as sp
 import scipy.special
 from aesara.graph.fg import FunctionGraph
-from numdifftools import Jacobian
+from numdifftools import Derivative, Jacobian
 
 from aeppl.joint_logprob import conditional_logprob, joint_logprob
 from aeppl.transforms import (
@@ -244,9 +244,7 @@ def test_transformed_logprob(at_dist, dist_params, sp_dist, size):
 
             exp_log_jac_val = jacobian_estimate(a_trans_value)
         else:
-            jacobian_val = np.atleast_2d(
-                sp.misc.derivative(a_backward_fn, a_trans_value, dx=1e-6)
-            )
+            jacobian_val = np.atleast_2d(Derivative(a_backward_fn)(a_trans_value))
             exp_log_jac_val = np.linalg.slogdet(jacobian_val)[-1]
 
         log_jac_val = log_jac_fn(a_trans_value)


### PR DESCRIPTION
Aside from updating the GitHub Actions versions, this PR includes a necessary replacement for our use of SciPy's deprecated/removed gradient function.