### PR TITLE
Explicitly remove AePPL IR from `conditional_logprob` results

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,11 +80,11 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v2
         with:
-          mamba-version: "*"
           channels: conda-forge,defaults
           channel-priority: true
           python-version: ${{ matrix.python-version }}
-          auto-update-conda: true
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
 
       - name: Create matrix id
         id: matrix-id

--- a/aeppl/abstract.py
+++ b/aeppl/abstract.py
@@ -144,6 +144,7 @@ class ValuedVariable(Op):
     directly.  An example is `BroadcastTo` lifting through `RandomVariable`\s.
     """
 
+    __props__ = ()
     default_output = 0
     view_map = {0: [0]}
 

--- a/aeppl/joint_logprob.py
+++ b/aeppl/joint_logprob.py
@@ -8,7 +8,7 @@ from aesara.tensor.var import TensorVariable
 
 from aeppl.abstract import ValuedVariable, get_measurable_outputs
 from aeppl.logprob import _logprob
-from aeppl.rewriting import construct_ir_fgraph
+from aeppl.rewriting import construct_ir_fgraph, ir_cleanup_db
 
 if TYPE_CHECKING:
     from aesara.graph.basic import Apply, Variable
@@ -219,11 +219,9 @@ def conditional_logprob(
         #     for node in io_toposort(graph_inputs([rv_logprobs]), outputs):
         #         compute_test_value(node)
 
-    # Replace `ValuedVariable`s with their values
+    # Remove unneeded IR elements from the graph
     rv_logprobs_fg = FunctionGraph(outputs=tuple(logprob_vars.values()), clone=False)
-    rv_logprobs_fg.replace_all(
-        tuple((valued_var, valued_var.owner.inputs[1]) for valued_var in fgraph.outputs)
-    )
+    ir_cleanup_db.query("+basic").rewrite(rv_logprobs_fg)
 
     return logprob_vars, value_vars
 

--- a/aeppl/transforms.py
+++ b/aeppl/transforms.py
@@ -24,7 +24,7 @@ from aeppl.abstract import (
     valued_variable,
 )
 from aeppl.logprob import _logprob, logprob
-from aeppl.rewriting import measurable_ir_rewrites_db
+from aeppl.rewriting import ir_cleanup_db, measurable_ir_rewrites_db
 
 if TYPE_CHECKING:
     from aesara.graph.rewriting.basic import NodeRewriter
@@ -75,6 +75,7 @@ class TransformedVariable(Op):
 
     """
 
+    __props__ = ()
     view_map = {0: [0]}
 
     def make_node(self, tran_value: TensorVariable, value: TensorVariable):
@@ -101,8 +102,12 @@ transformed_variable = TransformedVariable()
 @register_useless
 @node_rewriter([TransformedVariable])
 def remove_TransformedVariables(fgraph, node):
-    if isinstance(node.op, TransformedVariable):
-        return [node.inputs[0]]
+    return [node.inputs[0]]
+
+
+ir_cleanup_db.register(
+    "remove-TransformedVariables", in2out(remove_TransformedVariables), "basic"
+)
 
 
 class RVTransform(abc.ABC):

--- a/tests/test_abstract.py
+++ b/tests/test_abstract.py
@@ -2,6 +2,7 @@ import aesara
 import aesara.tensor as at
 import numpy as np
 import pytest
+from aesara.compile.mode import get_default_mode
 from aesara.gradient import NullTypeGradError, grad
 from aesara.tensor.random.basic import NormalRV
 
@@ -113,7 +114,9 @@ def test_valued_variable():
     obs_var = valued_variable(rv_var, rv_vv)
 
     rv_val = np.zeros(3)
-    res = obs_var.eval({rv_var: rv_val, rv_vv: np.ones(3)})
+    mode = get_default_mode().excluding("remove_ValuedVariable")
+    obs_var_fn = aesara.function([rv_var, rv_vv], obs_var, mode=mode)
+    res = obs_var_fn(rv_val, np.ones(3))
     assert np.array_equal(res, rv_val)
 
     with pytest.raises(NullTypeGradError):

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -190,11 +190,17 @@ def test_transformed_logprob(at_dist, dist_params, sp_dist, size):
     a_trans_op = _default_transformed_rv(a.owner.op, a.owner).op
     transform = a_trans_op.transform
 
+    # Remove the static shape assumptions from the value variable so that it's
+    # easier to construct the numerical Jacobian reference values in higher
+    # dimensions
+    a_value_var_gen = at.tensor(
+        dtype=a_value_var.type.dtype, shape=(None,) * a_value_var.type.ndim
+    )
     a_forward_fn = aesara.function(
-        [a_value_var], transform.forward(a_value_var, *a.owner.inputs)
+        [a_value_var_gen], transform.forward(a_value_var_gen, *a.owner.inputs)
     )
     a_backward_fn = aesara.function(
-        [a_value_var], transform.backward(a_value_var, *a.owner.inputs)
+        [a_value_var_gen], transform.backward(a_value_var_gen, *a.owner.inputs)
     )
     log_jac_fn = aesara.function(
         [a_value_var],


### PR DESCRIPTION
This PR adds a clean-up step to `conditional_logprob` that removes AePPL-specific IR.  It also has a couple important updates for recent CI and Aesara updates.

Closes #222.