### PR TITLE
Make `add_independent_normals` work with varargs

### DIFF
--- a/aeppl/convolutions.py
+++ b/aeppl/convolutions.py
@@ -7,37 +7,36 @@ from aeppl.rewriting import measurable_ir_rewrites_db
 
 @node_rewriter((at.sub, at.add))
 def add_independent_normals(fgraph, node):
-    """Replace a sum of two un-valued independent normal RVs with a single normal RV."""
+    """Replace a sum of un-valued independent normal RVs with a single normal RV."""
+
+    if len(node.inputs) < 2:
+        return None
 
     if node.op == at.add:
         sub = False
     else:
         sub = True
 
-    X_rv, Y_rv = node.inputs
-
-    if not (X_rv.owner and Y_rv.owner) or not (
-        # This also checks that the RVs are un-valued (i.e. they're not
-        # `ValuedVariable`s)
-        isinstance(X_rv.owner.op, NormalRV)
-        and isinstance(Y_rv.owner.op, NormalRV)
-    ):
+    # This also implicitly checks that the RVs are un-valued (i.e. they're not
+    # `ValuedVariable`s)
+    if not all(inp.owner and isinstance(inp.owner.op, NormalRV) for inp in node.inputs):
         return None
 
-    old_rv = node.outputs[0]
-
-    mu_x, sigma_x, mu_y, sigma_y, _ = at.broadcast_arrays(
-        *(X_rv.owner.inputs[-2:] + Y_rv.owner.inputs[-2:] + [old_rv])
+    new_size = at.broadcast_shape(
+        *(tuple(inp.owner.inputs[1]) for inp in node.inputs), arrays_are_shapes=True
     )
 
-    new_rng = X_rv.owner.inputs[0].clone()
+    means = [inp.owner.inputs[-2] for inp in node.inputs]
+    covs = [inp.owner.inputs[-1] ** 2 for inp in node.inputs]
+
+    new_rng = node.inputs[0].owner.inputs[0].clone()
 
     new_node = normal.make_node(
         new_rng,
-        old_rv.shape,
-        old_rv.dtype,
-        mu_x + mu_y if not sub else mu_x - mu_y,
-        at.sqrt(sigma_x**2 + sigma_y**2),
+        new_size,
+        node.outputs[0].dtype,
+        at.add(*means) if not sub else at.sub(*means),
+        at.sqrt(at.add(*covs)),
     )
 
     fgraph.add_input(new_rng)
@@ -45,9 +44,6 @@ def add_independent_normals(fgraph, node):
     # new_rng must be updated with values of the RNGs output by `new_node
     new_rng.default_update = new_node.outputs[0]
     new_normal_rv = new_node.default_output()
-
-    if old_rv.name:
-        new_normal_rv.name = old_rv.name
 
     return [new_normal_rv]
 


### PR DESCRIPTION
This PR updates `add_independent_normals` so that it works with a variable number of arguments.