### PR TITLE
Preserve the identities of value/observed variables

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,8 +3,12 @@ version: 2
 sphinx:
     configuration: docs/source/conf.py
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
 python:
-   version: "3.7"
    install:
    - requirements: requirements-docs.txt
    - method: pip

--- a/tests/test_convolutions.py
+++ b/tests/test_convolutions.py
@@ -74,7 +74,7 @@ def test_add_independent_normals(mu_x, mu_y, sigma_x, sigma_y, x_shape, y_shape,
     Z_rv.name = "Z"
     z_vv = Z_rv.clone()
 
-    fgraph, _, _ = construct_ir_fgraph({Z_rv: z_vv})
+    fgraph, *_ = construct_ir_fgraph({Z_rv: z_vv})
 
     (valued_var_out_node) = fgraph.outputs[0].owner
     # The convolution should be applied, and not the transform
@@ -108,7 +108,7 @@ def test_normal_add_input_valued():
     Z_rv.name = "Z"
     z_vv = Z_rv.clone()
 
-    fgraph, _, _ = construct_ir_fgraph({Z_rv: z_vv, X_rv: x_vv})
+    fgraph, *_ = construct_ir_fgraph({Z_rv: z_vv, X_rv: x_vv})
 
     valued_var_out_node = fgraph.outputs[0].owner
     # We should not expect the convolution to be applied; instead, the
@@ -136,7 +136,7 @@ def test_normal_add_three_inputs():
     Z_rv.name = "Z"
     z_vv = Z_rv.clone()
 
-    fgraph, _, _ = construct_ir_fgraph({Z_rv: z_vv})
+    fgraph, *_ = construct_ir_fgraph({Z_rv: z_vv})
 
     valued_var_out_node = fgraph.outputs[0].owner
     # The convolution should be applied, and not the transform

--- a/tests/test_mixture.py
+++ b/tests/test_mixture.py
@@ -685,7 +685,7 @@ def test_switch_mixture():
     z_vv = Z1_rv.clone()
     z_vv.name = "z1"
 
-    fgraph, _, _ = construct_ir_fgraph({Z1_rv: z_vv, I_rv: i_vv})
+    fgraph, *_ = construct_ir_fgraph({Z1_rv: z_vv, I_rv: i_vv})
 
     out_rv = fgraph.outputs[0].owner.inputs[0]
     assert isinstance(out_rv.owner.op, MixtureRV)
@@ -696,7 +696,7 @@ def test_switch_mixture():
 
     Z1_rv.name = "Z1"
 
-    fgraph, _, _ = construct_ir_fgraph({Z1_rv: z_vv, I_rv: i_vv})
+    fgraph, *_ = construct_ir_fgraph({Z1_rv: z_vv, I_rv: i_vv})
 
     out_rv = fgraph.outputs[0].owner.inputs[0]
     assert out_rv.name == "Z1-mixture"
@@ -705,7 +705,7 @@ def test_switch_mixture():
 
     Z2_rv = at.stack((X_rv, Y_rv))[I_rv]
 
-    fgraph2, _, _ = construct_ir_fgraph({Z2_rv: z_vv, I_rv: i_vv})
+    fgraph2, *_ = construct_ir_fgraph({Z2_rv: z_vv, I_rv: i_vv})
 
     assert equal_computations(fgraph.outputs, fgraph2.outputs)
 


### PR DESCRIPTION
This PR changes the IR generation process so that value/observed variables are never rewritten and their identities are necessarily preserved in the log-probability results.  Basically, we create dummy variables for them during IR rewriting and replace them with the value variables at the end (i.e. when log-probabilities are constructed).  Most of the changes have to do with the special case of transformations, which demand the ability to change transformed value variables _after_ IR rewriting.